### PR TITLE
Install docker-py from pip.

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -7,10 +7,3 @@
     dest: /etc/localtime
     state: link
     force: yes
-
-# epel provides python-docker-py package
-- name: enable epel-release repo
-  sudo: yes
-  yum:
-    name: epel-release
-    state: installed

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -2,11 +2,8 @@
 - name: install docker
   sudo: yes
   yum:
-    name: "{{ item }}"
+    name: docker
     state: latest
-  with_items:
-    - docker
-    - python-docker-py
 
 - name: enable docker
   sudo: yes
@@ -21,3 +18,26 @@
     name: "{{ ansible_ssh_user }}"
     groups: docker
     append: yes
+
+# required to install pip
+- name: install epel-release
+  sudo: yes
+  yum:
+    name: epel-release
+    state: present
+
+# required to install docker-py with pip
+- name: install python-pip
+  sudo: yes
+  yum:
+    name: python-pip
+    state: present
+
+# required for ansible docker module
+- name: install docker-py
+  sudo: yes
+  pip:
+    name: docker-py
+    # docker-py 0.4.0 works with ansible 1.8.2
+    version: 0.4.0
+    state: present


### PR DESCRIPTION
Switching to pip to install docker-py because EPEL 7 no longer has the package.

Using docker-py 0.4.0 because the latest version (0.7.1) doesn't work with Ansible 1.8.2 docker module.
