### PR TITLE
Add localhost dns lookup for the docker daemon.

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -5,6 +5,14 @@
     name: docker
     state: latest
 
+- name: docker consul dns
+  sudo: yes
+  lineinfile:
+    dest: /etc/sysconfig/docker 
+    state: present
+    regexp: ^OPTIONS
+    line: OPTIONS=--selinux-enabled -H fd:// --dns {{ ansible_eth0.ipv4.address }}  --dns-search service.consul
+
 - name: enable docker
   sudo: yes
   service:


### PR DESCRIPTION
This configures the docker daemon to use localhost via dnsmasq as a DNS resolver for all containers. 

When combined with consul, all containers will automatically resolve hosts registered in consul service discovery. 
