### PR TITLE
set preference for virtualbox provider for owners of vmware_fusion provi...

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,11 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
+
+  # Prefer VirtualBox before VMware Fusion  
+  config.vm.provider "virtualbox"
+  config.vm.provider "vmware_fusion"
+  
   config.vm.box = "CiscoCloud/shipped-devbox"
 
   config.vm.network :forwarded_port, guest: 2181, host: 2181  # ZooKeeper 


### PR DESCRIPTION
This sets preference for the virtualbox provider. Owners of vmware_fusion provider plugin to vagrant need this while your vmware box is missing.