### PR TITLE
Deprecated checkpoint flag prevents mesos-slave startup

### DIFF
--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,13 @@
+Example
+---
+
+`vagrant up`
+
+After Vagrant has had time to spin up the instance.
+
+1. Open a browser window to the [Marathon UI](http://127.0.0.1:8080/).
+2. Run `examples/hello-world/launch.sh -c examples/hello-world/hello-world.json -m 127.0.0.1` to start the _hello-world_ example. You will see the Marathon UI update with the new application as two instances are deployed.
+3. To get information about an app click on the row in the UI. Or, from the command line run `curl -s "http://127.0.0.1:8080/v2/apps/hello-world" | python json.tool`.
+4. To remove the application use the _Destroy App_ button on the details pop-up in the UI. Or, from the command line run `curl -s -X DELETE "http://127.0.0.1:8080/v2/apps/hello-world" | python json.tool`.
+
+See the [Marathon REST API Documentation](https://mesosphere.github.io/marathon/docs/rest-api.html) for more information on the options available.

--- a/roles/mesos/tasks/follower.yml
+++ b/roles/mesos/tasks/follower.yml
@@ -46,11 +46,3 @@
   tags:
     - mesos
 
-- name: enable follower task checkpoints
-  sudo: yes
-  copy: 
-    dest: /etc/mesos-slave/?checkpoint 
-    content: ""
-  notify: restart mesos follower
-  tags:
-    - mesos


### PR DESCRIPTION
Running vagrant up and trying the hello world example failed to
start the hello world containers. checking the logs i noticed the
mesos-slave kept failing. The existence of `/etc/mesos-slave/?checkpoint`
prevents the slave from starting.

Found references to the checkpoint flag and ultimately landed at the
[mesos changelog](https://github.com/apache/mesos/blob/master/CHANGELOG)

* Deprecations:
   * [MESOS-444] - Slave checkpoint flag has been removed as it will be enabled for all slaves.

Tracked down version of mesos installed.

`Mar 26 16:17:33 localhost yum[5144]: Installed: mesos-0.22.0-1.1.centos701406.x86_64`

`vagrant destroy`

remove checkpoint flag creation froom roles/mesos/tasks/follower.yaml

`vagrant up`

hello-world deploys correctly

`examples/hello-world/launch.sh -c examples/hello-world/hello-world.json -m 127.0.0.1`

Everything else *seems* ok in the logs, not seeing any other error
messages which indicate issues between mesos master/slave.
Not sure if the flag also served some other internal purpose, pls review.