### PR TITLE
Proposed layout for site.yml and fixed dnsmasq demonstration

### DIFF
--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -4,10 +4,6 @@
   sudo: yes
   command: systemctl disable dnsmasq
 
-- name: restart dnsmasq
-  sudo: yes
-  command: systemctl restart dnsmasq 
-
 - name: restart networkmanager
   sudo: yes
   command: systemctl restart NetworkManager

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -28,18 +28,6 @@
   tags:
     - dnsmasq
 
-# Resolve IPs via Consul before reboot
-- name: configure dnsmasq symlink
-  sudo: yes
-  file:
-    src: /etc/NetworkManager/dnsmasq.d/10-consul
-    dest: /etc/dnsmasq.d/10-consul 
-    state: link
-  notify:
-    - restart dnsmasq 
-  tags:
-    - dnsmasq 
-
 - name: configure networkmanager for dnsmasq
   sudo: yes
   lineinfile:
@@ -47,17 +35,6 @@
     line: "dns=dnsmasq"
     insertbefore: "^plugins"
   notify:
-    - disable dnsmasq
     - restart networkmanager
-  tags:
-    - dnsmasq
-
-- name: set localhost as nameserver
-  sudo: yes
-  lineinfile:
-    dest: /etc/resolv.conf
-    regexp: "^nameserver 127.0.0.1"
-    line: "nameserver 127.0.0.1"
-    insertafter: "^search"
   tags:
     - dnsmasq

--- a/site.yml
+++ b/site.yml
@@ -16,10 +16,25 @@
 - hosts: all
   roles:
     - common
+
+- hosts: all
+  roles:
     - docker
+
+- hosts: all
+  roles:
     - dnsmasq
+
+- hosts: all
+  roles:
     - nginx
+
+- hosts: all
+  roles:
     - consul
+
+- hosts: all
+  roles:
     - registrator
 
 - include: playbooks/consul-join-wan.yml


### PR DESCRIPTION
I'm proposing splitting the `all` play in site.yml into individual plays.

Ansible runs the handlers at the end of the play. With all of the roles in a list, the handlers aren't run until all of the roles are complete. This can cause installation issues due to dependencies. Splitting the plays out causes the handlers to run after the role is complete.

