### PR TITLE
Feature/nginx passwd

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-novaclient==2.17.0
 python-keystoneclient
 Sphinx==1.2.3
 alabaster==0.6.3
+bcrypt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ python-novaclient==2.17.0
 python-keystoneclient
 Sphinx==1.2.3
 alabaster==0.6.3
-bcrypt
+bcrypt==1.1.1

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -19,10 +19,4 @@
   when: hostvars[item].ansible_default_ipv4.address is defined
   with_items: groups['all']
 
-- name: install httpd-tools
-  sudo: yes
-  yum:
-    name: httpd-tools
-    state: present
-
 - include: users.yml

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -21,13 +21,3 @@
       dest: /etc/nginx/ssl/nginx.key
   tags:
     - nginx
-
-- name: encrypt admin password
-  sudo: yes
-  shell: htpasswd -Bnb admin {{ nginx_admin_password }} | cut -f 2 -d ':'
-  register: nginx_admin_password_encrypted
-  changed_when: no
-
-- name: set admin password variable
-  set_fact:
-    nginx_admin_password_encrypted: "{{ nginx_admin_password_encrypted.stdout }}"

--- a/security-setup
+++ b/security-setup
@@ -3,6 +3,7 @@
 from __future__ import print_function
 from argparse import ArgumentParser
 import base64
+import bcrypt
 from collections import OrderedDict
 from contextlib import contextmanager
 import getpass
@@ -289,9 +290,11 @@ class Nginx(Component):
                     purpose='admin',
                 )
                 print('set nginx admin password')
+
+                config['nginx_admin_password_encrypted'] = bcrypt.hashpw(config['nginx_admin_password'], bcrypt.gensalt())
+                print('creating encrypted nginx admin password')
             else:
                 print('nginx admin password already set')
-
 
 class Consul(Component):
     def check(self):

--- a/security-setup
+++ b/security-setup
@@ -296,6 +296,7 @@ class Nginx(Component):
             else:
                 print('nginx admin password already set')
 
+
 class Consul(Component):
     def check(self):
         return [self.gossip_key, self.master_acl_token, self.cert, self.default_acl_policy]


### PR DESCRIPTION
Move nginx admin password generation to security-setup script and off the host.

This allows us to remove the httpd-tools package install and doing a ssh->stdout roundtrip to generate a bcrypt hash.