### PR TITLE
automatically generate mesos auth flags

### DIFF
--- a/roles/mesos/README.rst
+++ b/roles/mesos/README.rst
@@ -103,14 +103,14 @@ do so.)
    Enable Mesos authentication for frameworks. You should set
    :data:`mesos_credentials` for credentials if this is set.
 
-   default: ``no``
+   default: set automatically if framework credentials are present
 
 .. data:: mesos_authenticate_followers
 
    Enable Mesos authentication from followers. If set, each follower will need
    :data:`mesos_follower_secret` set in their host variables.
 
-   default: ``no``
+   default: set automatically if follower credentials are present
 
 .. data:: mesos_follower_principal
 

--- a/roles/mesos/README.rst
+++ b/roles/mesos/README.rst
@@ -122,8 +122,7 @@ do so.)
 
    The secret to use for follower authentication
 
-   default: not set. Set this and :data:`mesos_authenticate_followers` to `true`
-   to enable follower authentication.
+   default: not set. Set this to enable follower authentication.
 
 .. _mesos-example-playbook:
 

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -31,8 +31,7 @@ mesos_zk_acl_cmd: "docker run --rm -e ZK_AUTH=super:{{ zk_super_user_secret }} -
 
 # authentication options
 mesos_credentials: []
-_mesos_principals: "{% for cred in mesos_credentials %}{% if cred.principal != mesos_follower_principal %}{{ cred.principal }}{% endif %}{% endfor %}"
-mesos_authenticate_frameworks: "{{ _mesos_principals != '' }}"
+mesos_authenticate_frameworks: "{{ mesos_credentials|length > 0 }}"
 mesos_authenticate_followers: "{{ mesos_follower_secret != '' }}"
 mesos_follower_principal: follower
 mesos_follower_secret: ""

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -31,8 +31,9 @@ mesos_zk_acl_cmd: "docker run --rm -e ZK_AUTH=super:{{ zk_super_user_secret }} -
 
 # authentication options
 mesos_credentials: []
-mesos_authenticate_frameworks: no
-mesos_authenticate_followers: no
+_mesos_principals: "{% for cred in mesos_credentials %}{% if cred.principal != mesos_follower_principal %}{{ cred.principal }}{% endif %}{% endfor %}"
+mesos_authenticate_frameworks: "{{ _mesos_principals != '' }}"
+mesos_authenticate_followers: "{{ mesos_follower_secret != '' }}"
 mesos_follower_principal: follower
 mesos_follower_secret: ""
 

--- a/roles/mesos/tasks/follower.yml
+++ b/roles/mesos/tasks/follower.yml
@@ -29,7 +29,7 @@
     - mesos  
 
 - name: write credential
-  when: mesos_authenticate_followers
+  when: mesos_authenticate_followers|bool
   sudo: yes
   copy:
     dest: /etc/mesos/follower-credential
@@ -40,7 +40,7 @@
     - mesos
 
 - name: delete credential
-  when: not mesos_authenticate_followers
+  when: not mesos_authenticate_followers|bool
   sudo: yes
   file:
     dest: /etc/mesos/follower-credential
@@ -50,7 +50,7 @@
     - mesos
 
 - name: enable credential option
-  when: mesos_authenticate_followers
+  when: mesos_authenticate_followers|bool
   sudo: yes
   copy:
     dest: /etc/mesos-slave/credential
@@ -60,7 +60,7 @@
     - mesos
 
 - name: disable credential option
-  when: not mesos_authenticate_followers
+  when: not mesos_authenticate_followers|bool
   sudo: yes
   file:
     dest: /etc/mesos-slave/credential

--- a/roles/mesos/tasks/leader.yml
+++ b/roles/mesos/tasks/leader.yml
@@ -11,7 +11,7 @@
 
 - name: write leader credentials
   sudo: yes
-  when: mesos_authenticate_frameworks or mesos_authenticate_followers
+  when: mesos_authenticate_frameworks|bool or mesos_authenticate_followers|bool
   template:
     src: master-credentials.j2
     dest: /etc/mesos/credentials
@@ -23,7 +23,7 @@
 
 - name: delete leader credentials
   sudo: yes
-  when: not mesos_authenticate_frameworks and not mesos_authenticate_followers
+  when: not mesos_authenticate_frameworks|bool and not mesos_authenticate_followers|bool
   file:
     dest: /etc/mesos/credentials
     state: absent

--- a/roles/mesos/templates/master-credentials.j2
+++ b/roles/mesos/templates/master-credentials.j2
@@ -1,6 +1,6 @@
 {%- for credential in mesos_credentials -%}
 {{ credential.principal }} {{ credential.secret }}
 {% endfor -%}
-{% if mesos_authenticate_followers %}
+{% if mesos_authenticate_followers|bool %}
 {{ mesos_follower_principal }} {{ mesos_follower_secret }}
 {% endif %}

--- a/roles/mesos/templates/master-defaults.j2
+++ b/roles/mesos/templates/master-defaults.j2
@@ -6,9 +6,9 @@ MESOS_QUORUM={{ groups.mesos_leaders|count // 2 + 1 }}
 export MESOS_HOSTNAME={{ mesos_hostname }}
 {% endif %}
 export MESOS_AUTHENTICATORS=crammd5
-{% if mesos_authenticate_frameworks %}export MESOS_AUTHENTICATE=true
+{% if mesos_authenticate_frameworks|bool %}export MESOS_AUTHENTICATE=true
 {% endif %}
-{% if mesos_authenticate_followers %}export MESOS_AUTHENTICATE_SLAVES=true
+{% if mesos_authenticate_followers|bool %}export MESOS_AUTHENTICATE_SLAVES=true
 {% endif %}
-{% if mesos_authenticate_frameworks or mesos_authenticate_followers %}export MESOS_CREDENTIALS=/etc/mesos/credentials
+{% if mesos_authenticate_frameworks|bool or mesos_authenticate_followers|bool %}export MESOS_CREDENTIALS=/etc/mesos/credentials
 {% endif %}

--- a/security-setup
+++ b/security-setup
@@ -411,7 +411,7 @@ class Zookeeper(Component):
 
 class Mesos(Component):  # Mesos should always come after any frameworks
     def check(self):
-        return [self.framework_auth, self.follower_auth]
+        return [self.framework_auth, self.follower_auth, self.deprecate]
 
     def framework_auth(self):
         "framework auth"
@@ -432,6 +432,30 @@ class Mesos(Component):  # Mesos should always come after any frameworks
             config.setdefault('mesos_follower_principal', 'follower')
             config.setdefault('mesos_follower_secret', self.random())
             print('enabled follower auth')
+
+    def deprecate(self):
+        "remove deprecated settings"
+        with self.modify_security() as config:
+            auth_frameworks = config.pop("mesos_authenticate_frameworks", None)
+            if auth_frameworks is not None:
+                print('removed mesos_authenticate_frameworks. This value is now automatically generated - see the docs.')
+
+            auth_followers = config.pop("mesos_authenticate_followers", None)
+            if auth_followers is not None:
+                print('removed mesos_authenticate_followers. This value is now automatically generated - see the docs.')
+
+            # remove follower credential from credential list
+            try:
+                credential_idx = config['mesos_credentials'].index({
+                    'principal': config['mesos_follower_principal'],
+                    'secret': config['mesos_follower_secret']
+                })
+            except ValueError:
+                credential_idx = None
+
+            if credential_idx is not None:
+                del config['mesos_credentials'][credential_idx]
+                print('removed follower credentials from credential list - it is now a separate setting.')
 
 
 def main(args):

--- a/security-setup
+++ b/security-setup
@@ -416,8 +416,6 @@ class Mesos(Component):  # Mesos should always come after any frameworks
     def framework_auth(self):
         "framework auth"
         with self.modify_security() as config:
-            frameworks = set(['marathon'])
-
             if 'marathon_principal' in config and 'marathon_secret' in config:
                 config.setdefault('mesos_credentials', [])
                 credential = {
@@ -428,28 +426,11 @@ class Mesos(Component):  # Mesos should always come after any frameworks
                     config['mesos_credentials'].append(credential)
                     print('set auth for Marathon')
 
-            else:
-                frameworks.remove('marathon')
-
-            authenticate = len(frameworks) > 0
-            config['mesos_authenticate_frameworks'] = authenticate
-            print('{} framework auth'.format('enabled' if authenticate else 'disabled'))
-
     def follower_auth(self):
         "follower auth"
         with self.modify_security() as config:
             config.setdefault('mesos_follower_principal', 'follower')
             config.setdefault('mesos_follower_secret', self.random())
-
-            credentials = {
-                'principal': config['mesos_follower_principal'],
-                'secret': config['mesos_follower_secret'],
-            }
-            if credentials not in config['mesos_credentials']:
-                config['mesos_credentials'].append(credentials)
-                print('added follower secret to leader config')
-
-            config['mesos_authenticate_followers'] = True
             print('enabled follower auth')
 
 


### PR DESCRIPTION
PR for #115.

This also adds a task in `security-setup` to deprecate values that had previously been set. I'd like feedback on that, especially from @stevendborrelli and @keithchambers, but also from anyone who cares about it.