### PR TITLE
Updated reboot-hosts.yml logic so that hosts are now rebooted in serial ...

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,8 @@ Fixes
 * OpenSSL certificate fixes #95
 * Fix ansible inventory metadata #96
 * Deprecated checkpoint flag prevents mesos-slave startup #105
-* remove duplicate definition of marathon_servers #101 
+* Remove duplicate definition of marathon_servers #101 
+* Running reboot-hosts.yml causes consul to lose quorum #132
 * Numeous other bug fixes
 
 0.1.0 (03-02-2015)

--- a/playbooks/reboot-hosts.yml
+++ b/playbooks/reboot-hosts.yml
@@ -1,9 +1,13 @@
 ---
 - include: ../openstack/provision-hosts.yml
 
-- hosts:  all
+- hosts: all
+  serial: 1
   gather_facts: no
   tasks:
+
+  - name: set consul maintenance enabled
+    command: consul maint -enable -reason "{{ lookup('env', 'USER') }} initiated reboot"
 
   - name: reboot host
     sudo: yes
@@ -15,6 +19,14 @@
       module: wait_for
       host: "{{ ansible_ssh_host }}"
       port: 22
-      delay: "{{ boot_wait | default(60) }}"
-      timeout: 120
+      search_regex: OpenSSH
+      delay: 90
+      timeout: 300
       state: started
+
+  - name: wait for consul to listen
+    wait_for:
+      port: 8500
+
+  - name: set consul maintenance disable
+    command: consul maint -disable

--- a/playbooks/reboot-hosts.yml
+++ b/playbooks/reboot-hosts.yml
@@ -6,7 +6,7 @@
   gather_facts: no
   tasks:
 
-  - name: set consul maintenance enabled
+  - name: set consul maintenance enable
     command: consul maint -enable -reason "{{ lookup('env', 'USER') }} initiated reboot"
 
   - name: reboot host


### PR DESCRIPTION
...to fix https://github.com/CiscoCloud/microservices-infrastructure/issues/132 where consul would lose quorum.  With this fix for each host we first enable consul maint mode, reboot, wait 90 seconds then verify ssh is up, next verify consul is up, and finally disable consul maint mode.