### PR TITLE
Move openstack security group to a variable

### DIFF
--- a/inventory/group_vars/all/all.yml
+++ b/inventory/group_vars/all/all.yml
@@ -7,4 +7,6 @@ os_flavor_ram: 4096
 os_flavor_include: Medium
 os_image_name: centos-7_x86_64-2015-01-27-v6
 
+security_group: default
+
 consul_servers_group: consul_servers

--- a/inventory/group_vars/all/all.yml
+++ b/inventory/group_vars/all/all.yml
@@ -7,6 +7,4 @@ os_flavor_ram: 4096
 os_flavor_include: Medium
 os_image_name: centos-7_x86_64-2015-01-27-v6
 
-security_group: default
-
 consul_servers_group: consul_servers

--- a/inventory/group_vars/dc1
+++ b/inventory/group_vars/dc1
@@ -8,3 +8,4 @@ os_tenant_name:
 os_tenant_id:
 os_net_id:
 consul_dc: dc1
+security_group: default

--- a/inventory/group_vars/dc2
+++ b/inventory/group_vars/dc2
@@ -8,3 +8,4 @@ os_tenant_name:
 os_tenant_id:
 os_net_id:
 consul_dc: dc2
+security_group: default

--- a/openstack/provision-hosts.yml
+++ b/openstack/provision-hosts.yml
@@ -19,7 +19,7 @@
         flavor_include: "{{ os_flavor_include }}"
         nics:
           - net-id: "{{ os_net_id }}"
-        security_groups: default
+        security_groups: "{{ security_group }}"
         state: "{{ nova_compute_state }}"
       always_run: yes
       register: host


### PR DESCRIPTION
Provide the ability for installer to specify their security group for Openstack in the configuration file instead of directly within the playbook.