### PR TITLE
Workaround for docker/issues/12108 added

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-- name: workaround for docker/issues/12108. Update device-mapper-libs to latest.
+# Workaround for https://github.com/CiscoCloud/microservices-infrastructure/issues/161 
+- name: install latest device-mapper-libs
   sudo: yes
   yum:
     name: device-mapper-libs

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: workaround for docker/issues/12108. Update device-mapper-libs to latest.
+  sudo: yes
+  yum:
+    name: device-mapper-libs
+    state: latest
+  tags:
+    - docker
+
 - name: install docker
   sudo: yes
   yum:


### PR DESCRIPTION
This PR works around an upstream issue with docker RPM Packaging.
Discussed in https://github.com/CiscoCloud/microservices-infrastructure/issues/161

Simple change. Testing now. Will confirm when complete on CCS CentOS7 base image.