### PR TITLE
Note Vagrant provider requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ A Vagrantfile is provided that provisions everything on a single VM. To run (ens
 1. Set up security. Run: `./security-setup`
 2. Provision box. Run: `vagrant up`
 
+Note that there is no support for the VMware Fusion Vagrant provider, so ensure that you set your provider to Virtualbox when running `vagrant up`: `vagrant up --provider=virtualbox`.
+
 
 ### Software Requirements
 


### PR DESCRIPTION
The box used in the Vagrantfile isn't compatible with VMware Fusion. Note
that Virtualbox is the only supported Vagrant provider.