### PR TITLE
Move Docker to overlayfs storage backend

### DIFF
--- a/playbooks/upgrade-packages.yml
+++ b/playbooks/upgrade-packages.yml
@@ -21,6 +21,11 @@
       name: "*"
       state: latest
 
+  - name: update grub
+    sudo: yes
+    shell: grub2-set-default 0 
+    when: kernel.changed 
+
   - name: reboot host
     sudo: yes
     shell: nohup bash -c "sleep 2s && reboot" &

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,0 +1,2 @@
+docker_storage_driver: overlay
+docker_selinux_disable: true

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -28,6 +28,32 @@
   tags:
     - docker
 
+- name: disable selinux
+  sudo: yes
+  lineinfile:
+    dest: /etc/sysconfig/docker
+    regexp: ^OPTIONS
+    line: OPTIONS=
+    state: present
+  when: docker_selinux_disable is defined
+  notify:
+    - restart docker
+  tags:
+   - docker
+
+- name: change storage backend 
+  sudo: yes
+  lineinfile:
+    dest: /etc/sysconfig/docker-storage
+    regexp: ^DOCKER_STORAGE_OPTIONS=
+    line: DOCKER_STORAGE_OPTIONS= -s {{ docker_storage_driver }}
+    state: present
+  when: docker_storage_driver is defined
+  notify: 
+    - restart docker
+  tags:
+    - docker
+
 - name: enable docker
   sudo: yes
   service:

--- a/roles/registrator/defaults/main.yml
+++ b/roles/registrator/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 registrator_image: gliderlabs/registrator
-registrator_image_tag: latest
+registrator_image_tag: v5


### PR DESCRIPTION
Uses overlay fs as the default filesystem. This requires Centos 7.1 and minimum kernel version of kernel-3.10.0-229.1.2.el7.x86_64.

Fixes #76

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ciscocloud/microservices-infrastructure/180)
<!-- Reviewable:end -->
