### PR TITLE
Fix/dnsmasq host

### DIFF
--- a/roles/dnsmasq/templates/10-consul
+++ b/roles/dnsmasq/templates/10-consul
@@ -1,6 +1,8 @@
 #Listen on all interfaces
 interface=*
 
+addn-hosts=/etc/hosts
+
 # Never forward addresses in the non-routed address spaces.
 bogus-priv
 

--- a/roles/mesos/files/mesos-leader-consul.cfg
+++ b/roles/mesos/files/mesos-leader-consul.cfg
@@ -1,5 +1,5 @@
 template {
 	source = "/etc/consul-template/templates/mesos-leader-iptables.tmpl"
-	destination = "/tmp/marathon-leader-iptables.sh"
-	command = "/bin/bash /tmp/marathon-leader-iptables.sh"
+	destination = "/tmp/mesos-leader-iptables.sh"
+	command = "/bin/bash /tmp/mesos-leader-iptables.sh"
 }


### PR DESCRIPTION
* Add entries in /etc/hosts to dnsmasq. The effect is that docker containers can resolve compute/resource host names
* Hide obvious copy/paste in mesos-leader role