### PR TITLE
generate sha256 signed CA/certs by default

### DIFF
--- a/ssl/openssl.cnf
+++ b/ssl/openssl.cnf
@@ -68,7 +68,7 @@ cert_opt 	= ca_default		# Certificate field options
 
 default_days	= 365			# how long to certify for
 default_crl_days= 30			# how long before next CRL
-default_md	= sha1			# which md to use.
+default_md	= sha256		# which md to use.
 preserve	= no			# keep passed DN ordering
 
 # A few difference way of specifying how similar the request should look


### PR DESCRIPTION
see https://community.qualys.com/blogs/securitylabs/2014/09/09/sha1-deprecation-what-you-need-to-know