### PR TITLE
Have awk read /proc/uptime directly

### DIFF
--- a/playbooks/show-uptime.yml
+++ b/playbooks/show-uptime.yml
@@ -3,7 +3,7 @@
   gather_facts: no
   tasks:
   - name: get uptime
-    shell: cat /proc/uptime | awk '{ print $1 }'
+    shell: awk '{ print $1 }' /proc/uptime
     register: uptime
     changed_when: no
 


### PR DESCRIPTION
Awk can read `/proc/uptime` directly, so no need to pipe it output from cat.