### PR TITLE
Hotfix: datanode used wron hdfs-site.xml

### DIFF
--- a/inventory/group_vars/data_nodes
+++ b/inventory/group_vars/data_nodes
@@ -1,0 +1,1 @@
+hdfs_namenode_host: host-01

--- a/spark.yml
+++ b/spark.yml
@@ -1,12 +1,12 @@
 ---
 # DC1
-- hosts: dc1:&name_node
+- hosts: dc1:&data_nodes
   gather_facts: no
   roles:
     - spark
 
 # DC2
-- hosts: dc2:&name_node
+- hosts: dc2:&data_nodes
   gather_facts: no
   roles:
     - spark


### PR DESCRIPTION
- create data_nodes invetory file with correct NameNode HDFS URL
- Install spark-shell at workes/slaves instead master node