### PR TITLE
Set correct path for the Docker options file

### DIFF
--- a/docs/security/security.rst
+++ b/docs/security/security.rst
@@ -178,7 +178,7 @@ CentOS. Docker 1.5 is the minimum version installed.
 
 -  ReST HTTP port is disabled
 -  Docker is started with SELinux enabled via
-   ``OPTIONS='--selinux-enabled'`` in ``/etc/default/docker``
+   ``OPTIONS='--selinux-enabled'`` in ``/etc/sysconfig/docker``
 
 Registrator
 ~~~~~~~~~~~


### PR DESCRIPTION
In CentOS the correct path is /etc/sysconfig/docker.