### PR TITLE
Stop managing consul.sysconif with Ansible

### DIFF
--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -46,8 +46,6 @@
     dest: "{{ item.dest }}"
     mode: "{{ item.mode | default('u=rw,g=r,o=r') }}"
   with_items:
-    - src: consul.sysconfig.j2
-      dest: /etc/sysconfig/consul
     - src: consul.json.j2
       dest: /etc/consul/consul.json
     - src: consul_nginx.service.j2

--- a/roles/consul/templates/consul.sysconfig.j2
+++ b/roles/consul/templates/consul.sysconfig.j2
@@ -1,1 +1,0 @@
-CMD_OPTS="agent -config-dir /etc/consul"


### PR DESCRIPTION
`consul.sysconfig` is provided by [consul-rpm](https://github.com/CiscoCloud/consul-rpm/blob/master/SOURCES/consul.sysconfig) and does not need to be managed by Ansible.

