### PR TITLE
Kafka: add ability to setup number and setting for brokers

### DIFF
--- a/roles/kafka/README.md
+++ b/roles/kafka/README.md
@@ -10,6 +10,9 @@
 - `mesos_lib`: Specify mesos library location. Default: `/usr/local/lib/libmesos.so`
 - `zookeeper_master`: Specify FQDN for zookeeper master. Default for MI project is `zookeeper.service.consul`
 - `marathon`: Specify FQDN for marathon services. Default for MI project is `marathon.service.consul`
+- `kafka_brokers`: Define number of brokers that will be used in your cluster. Default: 3
+- `kafka_broker_memory`: Specify Java memory setting for broker. Default: 2048
+- `kafka_broker_heap`: Specify Java heap for broker. Default: 1024 
 
 ## Example Playbook
 

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -5,3 +5,6 @@ kafka_mesos_repo: "https://github.com/mesos/kafka"
 mesos_lib: "/usr/local/lib/libmesos.so"
 zookeeper_master: "zookeeper.service.consul"
 marathon: "marathon.service.consul"
+kafka_brokers: 3
+kafka_broker_memory: 2048
+kafka_broker_heap: 1024 

--- a/roles/kafka/tasks/client.yml
+++ b/roles/kafka/tasks/client.yml
@@ -12,7 +12,7 @@
 - name: Add Kafka brockers  
   run_once: true
   sudo: true
-  command: "./kafka-mesos.sh add 0..2 --heap 1024 --mem 2048 --api http://{{ ansible_hostname }}:7000"
+  command: "./kafka-mesos.sh add  0..{{ kafka_brokers - 1 }} --heap {{ kafka_broker_heap }} --mem {{ kafka_broker_memory }} --api http://{{ ansible_hostname }}:7000"
   args:
     chdir: "{{ kafka_install_dir }}"
   tags:
@@ -21,7 +21,7 @@
 - name: Start Kafka brockers  
   run_once: true
   sudo: true
-  command: "./kafka-mesos.sh start 0..2 --api http://{{ ansible_hostname }}:7000"
+  command: "./kafka-mesos.sh start 0..{{ kafka_brokers - 1 }} --api http://{{ ansible_hostname }}:7000"
   args:
     chdir: "{{ kafka_install_dir }}"
   tags:


### PR DESCRIPTION
Add default settings:
- kafka_brokers that define how many brokers you plan to use in
cluster
- kafka_broker_memory define Java memory settings as far
kafka_broker_heap will define Java heap size.
To be remembered that heap size always at least twice smaller than
memory value. Default 2048 for Java memory and 1024 for Java
heap.

FeatureID: none