### PR TITLE
clean up security-setup options

### DIFF
--- a/docs/security/security_setup.rst
+++ b/docs/security/security_setup.rst
@@ -71,11 +71,11 @@ Options
    already have one. Setting this option will cause ``security-setup`` to
    re-prompt for the admin password.
 
-.. option:: --disable
+.. option:: --enable
 
-   Disable all security. This overrides all other options.
+   Enable (or disable, if False) all security. This overrides all other options.
 
-   Default: ``False``
+   Default: ``True``
 
 .. option:: --consul
 

--- a/docs/security/security_setup.rst
+++ b/docs/security/security_setup.rst
@@ -47,8 +47,8 @@ Options
 .. option:: --change-admin-password
 
    ``security-setup`` will normally ask for an admin password only if it doesn't
-   already have one. Setting this option will cause ``auth-setup`` to re-prompt
-   for the admin password.
+   already have one. Setting this option will cause ``security-setup`` to
+   re-prompt for the admin password.
 
 .. option:: --cert-country
 

--- a/docs/security/security_setup.rst
+++ b/docs/security/security_setup.rst
@@ -99,3 +99,69 @@ Options
    the nginx certificate.
 
    default: ``nginx.example.com``
+
+.. option:: --consul-auth
+
+   enable Consul authentication
+
+   default: ``True``
+
+.. option:: --consul-ssl
+
+   enable Consul SSL
+
+   default: ``True``
+
+.. option:: --consul-acl
+
+   enable Consul ACLs
+
+   default: ``True``
+
+.. option:: --mesos-ssl
+
+   enable Mesos SSL
+
+   default: ``True``
+
+.. option:: --mesos-auth
+
+   enable Mesos authentication
+
+   default: ``True``
+
+.. option:: --mesos-framework-auth
+
+   enable Mesos framework authentication
+
+   default: ``True``
+
+.. option:: --mesos-follower-auth
+
+   enable Mesos follower authentication
+
+   default: ``True``
+
+.. option:: --mesos-iptables
+
+   enable Mesos iptables rules to restrict access
+
+   default: ``True``
+
+.. option:: --marathon-ssl
+
+   enable Marathon SSL
+
+   default: ``True``
+
+.. option:: --marathon-auth
+
+   enable Marathon authentication
+
+   default: ``True``
+
+.. option:: --marathon-iptables
+
+   enable Marathon iptables rules to restrict access
+
+   default: ``True``

--- a/docs/security/security_setup.rst
+++ b/docs/security/security_setup.rst
@@ -28,6 +28,27 @@ In the event that you need to regenerate a certificate, rename or delete the
 appropriate CSR and certificate from the ``certs`` folder and the private
 component in ``private`` and re-run ``security-setup``.
 
+Boolean Options
+---------------
+
+Options like :ref:`--mesos` take a boolean argument. You can use the following
+values (and their ilk) in these options:
+
+======= ==============
+Value   Interpreted as
+======= ==============
+`t`     True
+`t`     True
+`1`     True
+`True`  True
+`true`  True
+`f`     False
+`F`     False
+`0`     False
+`False` False
+`false` False
+======= ==============
+
 Options
 -------
 

--- a/docs/security/security_setup.rst
+++ b/docs/security/security_setup.rst
@@ -50,6 +50,36 @@ Options
    already have one. Setting this option will cause ``security-setup`` to
    re-prompt for the admin password.
 
+.. option:: --disable
+
+   Disable all security. This overrides all other options.
+
+   Default: ``False``
+
+.. option:: --consul
+
+   Enable Consul security. This overrides all other Consul options.
+
+   Default: ``True``
+
+.. option:: --mesos
+
+   Enable Mesos security. This overrides all other Mesos options.
+
+   Default: ``True``
+
+.. option:: --marathon
+
+   Enable Marathon security. This overrides all other Marathon options.
+
+   Default: ``True``
+
+.. option:: --iptables
+
+   Use iptables rules. This overrides all other options related to iptables.
+
+   Default: ``True``
+
 .. option:: --cert-country
 
    Country to be used for certificates

--- a/security-setup
+++ b/security-setup
@@ -53,19 +53,19 @@ disable_opts.add_argument(
 )
 disable_opts.add_argument(
     '--consul', type=bool_opt, default=True,
-    help='enable or disable all Consul security'
+    help='Enable Consul security. This overrides all other Consul options.'
 )
 disable_opts.add_argument(
     '--mesos', type=bool_opt, default=True,
-    help='disable all Mesos security'
+    help='Enable Mesos security. This overrides all other Mesos options.'
 )
 disable_opts.add_argument(
     '--marathon', type=bool_opt, default=True,
-    help='disable all Marathon security'
+    help='Enable Marathon security. This overrides all other Marathon options.'
 )
 disable_opts.add_argument(
     '--iptables', type=bool_opt, default=True,
-    help='disable all iptable rules'
+    help='Use iptables rules. This overrides all other options related to iptables.'
 )
 
 # certificates

--- a/security-setup
+++ b/security-setup
@@ -24,7 +24,7 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument(
     '--change-admin-password', action='store_true',
-    help='change admin password'
+    help='change admin password during this run'
 )
 
 def bool_opt(string):

--- a/security-setup
+++ b/security-setup
@@ -91,17 +91,17 @@ consul_opts = parser.add_argument_group(
 )
 consul_opts.add_argument(
     '--consul-auth', type=bool_opt, default=True,
-    help='enable consul auth',
+    help='enable Consul auth',
     dest='do_consul_auth'
 )
 consul_opts.add_argument(
     '--consul-ssl', type=bool_opt, default=True,
-    help='enable consul auth',
+    help='enable Consul auth',
     dest='do_consul_ssl',
 )
 consul_opts.add_argument(
     '--consul-acl', type=bool_opt, default=True,
-    help='enable consul ACLs',
+    help='enable Consul ACLs',
     dest='do_consul_acl'
 )
 
@@ -112,27 +112,27 @@ mesos_opts = parser.add_argument_group(
 )
 mesos_opts.add_argument(
     '--mesos-ssl', type=bool_opt,
-    help='enable mesos ssl',
+    help='enable Mesos SSL',
     dest='do_mesos_ssl', default=True,
 )
 mesos_opts.add_argument(
     '--mesos-auth', type=bool_opt,
-    help='enable or enable mesos auth',
+    help='enable Mesos authentication',
     dest='do_mesos_auth', default=True,
 )
 mesos_opts.add_argument(
     '--mesos-framework-auth', type=bool_opt,
-    help='enable mesos framework auth',
+    help='enable Mesos framework authentication',
     dest='do_mesos_framework_auth', default=True,
 )
 mesos_opts.add_argument(
     '--mesos-follower-auth', type=bool_opt,
-    help='enable mesos follower auth',
+    help='enable Mesos follower authentication',
     dest='do_mesos_follower_auth', default=True,
 )
 mesos_opts.add_argument(
     '--mesos-iptables', type=bool_opt,
-    help='enable mesos iptables',
+    help='enable Mesos iptables rules',
     dest='do_mesos_iptables', default=True,
 )
 
@@ -143,17 +143,17 @@ marathon_opts = parser.add_argument_group(
 )
 marathon_opts.add_argument(
     '--marathon-ssl', type=bool_opt,
-    help='enable marathon ssl',
+    help='enable Marathon SSL',
     dest='do_marathon_ssl', default=True
 )
 marathon_opts.add_argument(
     '--marathon-auth', type=bool_opt,
-    help='enable marathon auth',
+    help='enable Marathon authentication',
     dest='do_marathon_auth', default=True
 )
 marathon_opts.add_argument(
     '--marathon-iptables', type=bool_opt,
-    help='enable marathon iptables',
+    help='enable Marathon iptables rules',
     dest='do_marathon_iptables', default=True
 )
 

--- a/security-setup
+++ b/security-setup
@@ -55,6 +55,10 @@ disable_opts.add_argument(
     '--disable-consul', action='store_true',
     help='disable all Consul security'
 )
+disable_opts.add_argument(
+    '--disable-mesos', action='store_true',
+    help='disable all Mesos security'
+)
 
 # certificates
 cert_opts = parser.add_argument_group(
@@ -566,6 +570,10 @@ class Zookeeper(Component):
 class Mesos(Component):  # Mesos should always come after any frameworks
     def check(self):
         return [self.disable_security, self.framework_auth, self.follower_auth, self.deprecate]
+
+    @property
+    def disabled(self):
+        return self.args.disable or self.args.disable_consul
 
     def disable_security(self):
         "disable security"

--- a/security-setup
+++ b/security-setup
@@ -141,12 +141,21 @@ marathon_opts = parser.add_argument_group(
     "Marathon Options",
     "enable and disable auth components of Marathon"
 )
-marathon_opts.add_argument('--disable-marathon-ssl', action='store_false', help='disable marathon ssl', dest='do_marathon_ssl', default=None)
-marathon_opts.add_argument('--enable-marathon-ssl', action='store_false', help='enable marathon ssl', dest='do_marathon_ssl')
-marathon_opts.add_argument('--disable-marathon-auth', action='store_false', help='disable marathon auth', dest='do_marathon_auth', default=None)
-marathon_opts.add_argument('--enable-marathon-auth', action='store_false', help='enable marathon auth', dest='do_marathon_auth')
-marathon_opts.add_argument('--disable-marathon-iptables', action='store_false', help='disable marathon iptables', dest='do_marathon_iptables', default=None)
-marathon_opts.add_argument('--enable-marathon-iptables', action='store_false', help='enable marathon iptables', dest='do_marathon_iptables', default=None)
+marathon_opts.add_argument(
+    '--marathon-ssl', type=bool_opt,
+    help='enable marathon ssl',
+    dest='do_marathon_ssl', default=True
+)
+marathon_opts.add_argument(
+    '--marathon-auth', type=bool_opt,
+    help='enable marathon auth',
+    dest='do_marathon_auth', default=True
+)
+marathon_opts.add_argument(
+    '--marathon-iptables', type=bool_opt,
+    help='enable marathon iptables',
+    dest='do_marathon_iptables', default=True
+)
 
 BASE = posixpath.abspath(posixpath.dirname(__file__)).replace("\\","/")
 SECURITY_FILE = posixpath.join(BASE, 'security.yml')

--- a/security-setup
+++ b/security-setup
@@ -84,8 +84,8 @@ class ImplicitBool(object):
 # disables
 broad_opts = parser.add_argument_group(
     "Broad Options",
-    "Control security for entire components. This overrides any more specific "
-    "options set from the sections below."
+    "enable or disable security for entire components. This overrides any more "
+    "specific options set from the sections below."
 )
 broad_opts.add_argument(
     '--enable', type=ImplicitBool.parse_opt, default=ImplicitBool.IMPLICIT_TRUE,

--- a/security-setup
+++ b/security-setup
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """set up authentication and security for various components"""
 from __future__ import print_function
-from argparse import ArgumentParser
+import argparse
 import base64
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -18,7 +18,10 @@ import sys
 import uuid
 import yaml
 
-parser = ArgumentParser(__name__, __doc__)
+parser = argparse.ArgumentParser(
+    __name__, __doc__,
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
 parser.add_argument(
     '--no-verify-certificates', action='store_true',
     help='skip verifying certificates'
@@ -29,14 +32,43 @@ parser.add_argument(
 )
 
 # certificates
-parser.add_argument('--cert-country', default='US')
-parser.add_argument('--cert-state', default='New York')
-parser.add_argument('--cert-locality', default='Anytown')
-parser.add_argument('--cert-organization', default='Example Company Inc')
-parser.add_argument('--cert-unit', default='Operations')
-parser.add_argument('--cert-email', default='operations@example.com')
-parser.add_argument('--consul-location', default='consul.service.consul')  # used as common name
-parser.add_argument('--nginx-location', default='*.service.consul')  # used as common name
+certs = parser.add_argument_group(
+    "SSL Certificate Options",
+    "a certificate authority will be set up, and "
+    "certificates will be issued using these options",
+)
+certs.add_argument(
+    '--cert-country', default='US',
+    help='certificate country'
+)
+certs.add_argument(
+    '--cert-state', default='New York',
+    help='certificate state/province'
+)
+certs.add_argument(
+    '--cert-locality', default='Anytown',
+    help='certificate locality/city'
+)
+certs.add_argument(
+    '--cert-organization', default='Example Company Inc',
+    help='certificate organization'
+)
+certs.add_argument(
+    '--cert-unit', default='Operations',
+    help='organizational unit inside of organization',
+)
+certs.add_argument(
+    '--cert-email', default='operations@example.com',
+    help='contact email for organizational unit'
+)
+certs.add_argument(
+    '--consul-location', default='consul.service.consul',
+    help='internal name for Consul certificate, will be used as common name'
+)
+certs.add_argument(
+    '--nginx-location', default='*.service.consul',
+    help='internal name for Nginx proxies, will be used as common name'
+)
 
 # Consul authentication
 parser.add_argument('--disable-consul-auth', action='store_false', help='disable consul auth', dest='do_consul_auth', default=None)

--- a/security-setup
+++ b/security-setup
@@ -63,6 +63,10 @@ disable_opts.add_argument(
     '--disable-marathon', action='store_true',
     help='disable all Marathon security'
 )
+disable_opts.add_argument(
+    '--disable-iptables', action='store_true',
+    help='disable all iptable rules'
+)
 
 # certificates
 cert_opts = parser.add_argument_group(
@@ -505,7 +509,11 @@ class Marathon(Component):
         "disable security"
         self.toggle_boolean('do_marathon_auth', self.args.do_marathon_auth and self.enabled, True)
         self.toggle_boolean('do_marathon_ssl', self.args.do_marathon_ssl and self.enabled, True)
-        self.toggle_boolean('do_marathon_iptables', self.args.do_marathon_ssl and self.enabled, True)
+        self.toggle_boolean(
+            'do_marathon_iptables',
+            self.args.do_marathon_ssl and self.enabled and not self.args.disable_iptables,
+            True
+        )
 
     def mesos_auth(self):
         "marathon framework authentication"
@@ -589,7 +597,11 @@ class Mesos(Component):  # Mesos should always come after any frameworks
         self.toggle_boolean('do_mesos_auth', self.args.do_mesos_auth and self.enabled, True)
         self.toggle_boolean('do_mesos_follower_auth', self.args.do_mesos_follower_auth and self.enabled, True)
         self.toggle_boolean('do_mesos_framework_auth', self.args.do_mesos_framework_auth and self.enabled, True)
-        self.toggle_boolean('do_mesos_iptables', self.args.do_mesos_framework_auth and self.enabled, True)
+        self.toggle_boolean(
+            'do_mesos_iptables',
+            self.args.do_mesos_framework_auth and self.enabled and not self.args.disable_iptables,
+            True
+        )
 
     def framework_auth(self):
         "framework auth"

--- a/security-setup
+++ b/security-setup
@@ -59,6 +59,10 @@ disable_opts.add_argument(
     '--disable-mesos', action='store_true',
     help='disable all Mesos security'
 )
+disable_opts.add_argument(
+    '--disable-marathon', action='store_true',
+    help='disable all Marathon security'
+)
 
 # certificates
 cert_opts = parser.add_argument_group(
@@ -492,6 +496,10 @@ class Consul(Component):
 class Marathon(Component):
     def check(self):
         return [self.disable_security, self.mesos_auth, self.password]
+
+    @property
+    def disabled(self):
+        return self.args.disable or self.args.disable_marathon
 
     def disable_security(self):
         "disable security"

--- a/security-setup
+++ b/security-setup
@@ -84,7 +84,7 @@ class ImplicitBool(object):
 # disables
 broad_opts = parser.add_argument_group(
     "Broad Options",
-    "disable security for entire components. This overrides any more specific "
+    "Control security for entire components. This overrides any more specific "
     "options set from the sections below."
 )
 broad_opts.add_argument(

--- a/security-setup
+++ b/security-setup
@@ -91,17 +91,17 @@ consul_opts = parser.add_argument_group(
 )
 consul_opts.add_argument(
     '--consul-auth', type=bool_opt, default=True,
-    help='enable or disable consul auth',
+    help='enable consul auth',
     dest='do_consul_auth'
 )
 consul_opts.add_argument(
     '--consul-ssl', type=bool_opt, default=True,
-    help='enable or disable consul auth',
+    help='enable consul auth',
     dest='do_consul_ssl',
 )
 consul_opts.add_argument(
     '--consul-acl', type=bool_opt, default=True,
-    help='enable or disable consul ACLs',
+    help='enable consul ACLs',
     dest='do_consul_acl'
 )
 
@@ -110,16 +110,31 @@ mesos_opts = parser.add_argument_group(
     "Mesos Options",
     "enable and disable auth components of Mesos"
 )
-mesos_opts.add_argument('--disable-mesos-ssl', action='store_false', help='disable mesos ssl', dest='do_mesos_ssl', default=None)
-mesos_opts.add_argument('--enable-mesos-ssl', action='store_false', help='enable mesos ssl', dest='do_mesos_ssl')
-mesos_opts.add_argument('--disable-mesos-auth', action='store_false', help='disable mesos auth', dest='do_mesos_auth', default=None)
-mesos_opts.add_argument('--enable-mesos-auth', action='store_false', help='enable mesos auth', dest='do_mesos_auth')
-mesos_opts.add_argument('--disable-mesos-framework-auth', action='store_false', help='disable mesos framework auth', dest='do_mesos_framework_auth', default=None)
-mesos_opts.add_argument('--enable-mesos-framework-auth', action='store_false', help='enable mesos framework auth', dest='do_mesos_framework_auth')
-mesos_opts.add_argument('--disable-mesos-follower-auth', action='store_false', help='disable mesos follower auth', dest='do_mesos_follower_auth', default=None)
-mesos_opts.add_argument('--enable-mesos-follower-auth', action='store_false', help='enable mesos follower auth', dest='do_mesos_follower_auth')
-mesos_opts.add_argument('--disable-mesos-iptables', action='store_false', help='disable mesos iptables', dest='do_mesos_iptables', default=None)
-mesos_opts.add_argument('--enable-mesos-iptables', action='store_false', help='enable mesos iptables', dest='do_mesos_iptables', default=None)
+mesos_opts.add_argument(
+    '--mesos-ssl', type=bool_opt,
+    help='enable mesos ssl',
+    dest='do_mesos_ssl', default=True,
+)
+mesos_opts.add_argument(
+    '--mesos-auth', type=bool_opt,
+    help='enable or enable mesos auth',
+    dest='do_mesos_auth', default=True,
+)
+mesos_opts.add_argument(
+    '--mesos-framework-auth', type=bool_opt,
+    help='enable mesos framework auth',
+    dest='do_mesos_framework_auth', default=True,
+)
+mesos_opts.add_argument(
+    '--mesos-follower-auth', type=bool_opt,
+    help='enable mesos follower auth',
+    dest='do_mesos_follower_auth', default=True,
+)
+mesos_opts.add_argument(
+    '--mesos-iptables', type=bool_opt,
+    help='enable mesos iptables',
+    dest='do_mesos_iptables', default=True,
+)
 
 # Marathon security
 marathon_opts = parser.add_argument_group(

--- a/security-setup
+++ b/security-setup
@@ -41,6 +41,17 @@ def bool_opt(string):
             '"%s" is not allowed. Try "true" or "false"' % string
         )
 
+# disables
+disable_opts = parser.add_argument_group(
+    "Broad Disable Options",
+    "disable security for entire components. This overrides any more specific "
+    "options set from the sections below."
+)
+disable_opts.add_argument(
+    '--disable', action='store_true',
+    help='disable all security. This overrides everything.'
+)
+
 # certificates
 cert_opts = parser.add_argument_group(
     "SSL Certificate Options",
@@ -181,6 +192,14 @@ class Component(object):
     def check(self, subset):
         """return tasks which need to be run"""
         return []
+
+    @property
+    def disabled(self):
+        return self.args.disable
+
+    @property
+    def enabled(self):
+        return not self.disabled
 
     def read_security(self):
         try:
@@ -352,9 +371,10 @@ class Component(object):
         with self.modify_security() as config:
             if inFlag not in config:
                 config[inFlag] = inDefault
-            
+
             if inValue is not None:
                 config[inFlag] = inValue
+
 
 class Certificates(Component):
     def check(self):
@@ -421,9 +441,9 @@ class Consul(Component):
 
     def disable_security(self):
         "disable security"
-        self.toggle_boolean('do_consul_auth', self.args.do_consul_auth, True)
-        self.toggle_boolean('do_consul_ssl', self.args.do_consul_ssl, True)
-        self.toggle_boolean('do_consul_acl', self.args.do_consul_acl, True)
+        self.toggle_boolean('do_consul_auth', self.args.do_consul_auth and self.enabled, True)
+        self.toggle_boolean('do_consul_ssl', self.args.do_consul_ssl and self.enabled, True)
+        self.toggle_boolean('do_consul_acl', self.args.do_consul_acl and self.enabled, True)
 
     def gossip_key(self):
         "gossip key"
@@ -463,10 +483,9 @@ class Marathon(Component):
 
     def disable_security(self):
         "disable security"
-        self.toggle_boolean('do_marathon_auth', self.args.do_marathon_auth, True)
-        self.toggle_boolean('do_marathon_ssl', self.args.do_marathon_ssl, True)
-        self.toggle_boolean('do_marathon_iptables', self.args.do_marathon_ssl, True)
-
+        self.toggle_boolean('do_marathon_auth', self.args.do_marathon_auth and self.enabled, True)
+        self.toggle_boolean('do_marathon_ssl', self.args.do_marathon_ssl and self.enabled, True)
+        self.toggle_boolean('do_marathon_iptables', self.args.do_marathon_ssl and self.enabled, True)
 
     def mesos_auth(self):
         "marathon framework authentication"
@@ -535,17 +554,18 @@ class Zookeeper(Component):
             else:
                 print('zk marathon user secret already set')
 
+
 class Mesos(Component):  # Mesos should always come after any frameworks
     def check(self):
         return [self.disable_security, self.framework_auth, self.follower_auth, self.deprecate]
 
     def disable_security(self):
         "disable security"
-        self.toggle_boolean('do_mesos_ssl', self.args.do_mesos_ssl, True)
-        self.toggle_boolean('do_mesos_auth', self.args.do_mesos_auth, True)
-        self.toggle_boolean('do_mesos_follower_auth', self.args.do_mesos_follower_auth, True)
-        self.toggle_boolean('do_mesos_framework_auth', self.args.do_mesos_framework_auth, True)
-        self.toggle_boolean('do_mesos_iptables', self.args.do_mesos_framework_auth, True)
+        self.toggle_boolean('do_mesos_ssl', self.args.do_mesos_ssl and self.enabled, True)
+        self.toggle_boolean('do_mesos_auth', self.args.do_mesos_auth and self.enabled, True)
+        self.toggle_boolean('do_mesos_follower_auth', self.args.do_mesos_follower_auth and self.enabled, True)
+        self.toggle_boolean('do_mesos_framework_auth', self.args.do_mesos_framework_auth and self.enabled, True)
+        self.toggle_boolean('do_mesos_iptables', self.args.do_mesos_framework_auth and self.enabled, True)
 
     def framework_auth(self):
         "framework auth"

--- a/security-setup
+++ b/security-setup
@@ -48,23 +48,23 @@ disable_opts = parser.add_argument_group(
     "options set from the sections below."
 )
 disable_opts.add_argument(
-    '--disable', action='store_true',
+    '--disable', action='store_true', default=False,
     help='disable all security. This overrides everything.'
 )
 disable_opts.add_argument(
-    '--disable-consul', action='store_true',
-    help='disable all Consul security'
+    '--consul', type=bool_opt, default=True,
+    help='enable or disable all Consul security'
 )
 disable_opts.add_argument(
-    '--disable-mesos', action='store_true',
+    '--mesos', type=bool_opt, default=True,
     help='disable all Mesos security'
 )
 disable_opts.add_argument(
-    '--disable-marathon', action='store_true',
+    '--marathon', type=bool_opt, default=True,
     help='disable all Marathon security'
 )
 disable_opts.add_argument(
-    '--disable-iptables', action='store_true',
+    '--iptables', type=bool_opt, default=True,
     help='disable all iptable rules'
 )
 
@@ -457,7 +457,7 @@ class Consul(Component):
 
     @property
     def disabled(self):
-        return self.args.disable or self.args.disable_consul
+        return self.args.disable or not self.args.consul
 
     def disable_security(self):
         "disable security"
@@ -503,7 +503,7 @@ class Marathon(Component):
 
     @property
     def disabled(self):
-        return self.args.disable or self.args.disable_marathon
+        return self.args.disable or not self.args.marathon
 
     def disable_security(self):
         "disable security"
@@ -511,7 +511,7 @@ class Marathon(Component):
         self.toggle_boolean('do_marathon_ssl', self.args.do_marathon_ssl and self.enabled, True)
         self.toggle_boolean(
             'do_marathon_iptables',
-            self.args.do_marathon_ssl and self.enabled and not self.args.disable_iptables,
+            self.args.do_marathon_ssl and self.enabled and self.args.iptables,
             True
         )
 
@@ -589,7 +589,7 @@ class Mesos(Component):  # Mesos should always come after any frameworks
 
     @property
     def disabled(self):
-        return self.args.disable or self.args.disable_consul
+        return self.args.disable or not self.args.mesos
 
     def disable_security(self):
         "disable security"
@@ -599,7 +599,7 @@ class Mesos(Component):  # Mesos should always come after any frameworks
         self.toggle_boolean('do_mesos_framework_auth', self.args.do_mesos_framework_auth and self.enabled, True)
         self.toggle_boolean(
             'do_mesos_iptables',
-            self.args.do_mesos_framework_auth and self.enabled and not self.args.disable_iptables,
+            self.args.do_mesos_framework_auth and self.enabled and self.args.iptables,
             True
         )
 

--- a/security-setup
+++ b/security-setup
@@ -15,17 +15,31 @@ import stat
 import string
 from subprocess import Popen, PIPE
 import sys
+import textwrap
 import uuid
 import yaml
 
+
+class HelpFormatter(argparse.RawTextHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
+    pass
+
 parser = argparse.ArgumentParser(
     __file__, __doc__,
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    epilog='''
+    formatter_class=HelpFormatter,
+    epilog=textwrap.dedent('''\
     Examples:
 
-    ...
-    '''
+      {name}
+                            enable or re-enable all security options
+      {name} --enable=false
+                            disable all security options
+      {name} --iptables=false --consul-ssl=false
+                            disable iptables rules and Consul SSL
+      {name} --change-admin-password --enable=true
+                            explicitly enable or re-enable every service (any
+                            other disables will be ignored) and re-prompt for
+                            the admin password.
+    '''.format(name=__file__))
 )
 parser.add_argument(
     '--change-admin-password', action='store_true',

--- a/security-setup
+++ b/security-setup
@@ -27,18 +27,18 @@ parser.add_argument(
     help='change admin password during this run'
 )
 
-def bool_opt(string):
-    if len(string) == 0:
+def bool_opt(raw_opt):
+    if len(raw_opt) == 0:
         raise argparse.ArgumentTypeError('blank is not allowed')
 
-    char = string[0].lower()
+    char = raw_opt[0].lower()
     if char in ['1', 't']:
         return True
     elif char in ['0', 'f']:
         return False
     else:
         raise argparse.ArgumentTypeError(
-            '"%s" is not allowed. Try "true" or "false"' % string
+            '"%s" is not allowed. Try "true" or "false"' % raw_opt
         )
 
 # disables

--- a/security-setup
+++ b/security-setup
@@ -51,6 +51,10 @@ disable_opts.add_argument(
     '--disable', action='store_true',
     help='disable all security. This overrides everything.'
 )
+disable_opts.add_argument(
+    '--disable-consul', action='store_true',
+    help='disable all Consul security'
+)
 
 # certificates
 cert_opts = parser.add_argument_group(
@@ -438,6 +442,10 @@ class Nginx(Component):
 class Consul(Component):
     def check(self):
         return [self.disable_security, self.gossip_key, self.master_acl_token, self.cert, self.default_acl_policy]
+
+    @property
+    def disabled(self):
+        return self.args.disable or self.args.disable_consul
 
     def disable_security(self):
         "disable security"

--- a/security-setup
+++ b/security-setup
@@ -19,52 +19,78 @@ import uuid
 import yaml
 
 parser = argparse.ArgumentParser(
-    __name__, __doc__,
+    __file__, __doc__,
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    epilog='''
+    Examples:
+
+    ...
+    '''
 )
 parser.add_argument(
     '--change-admin-password', action='store_true',
     help='change admin password during this run'
 )
 
-def bool_opt(raw_opt):
-    if len(raw_opt) == 0:
-        raise argparse.ArgumentTypeError('blank is not allowed')
 
-    char = raw_opt[0].lower()
-    if char in ['1', 't']:
-        return True
-    elif char in ['0', 'f']:
-        return False
-    else:
-        raise argparse.ArgumentTypeError(
-            '"%s" is not allowed. Try "true" or "false"' % raw_opt
-        )
+class ImplicitBool(object):
+    TRUE = True
+    FALSE = False
+    IMPLICIT_TRUE = 'True'  # this just has to be a different type/value than the real True
+
+    def __init__(self, value, explicit):
+        self.value = value
+        self.explicit = explicit
+
+    def __nonzero__(self):
+        return self.value
+
+    @classmethod
+    def represent(cls, dumper, obj):
+        return dumper.represent_bool(obj.value)
+
+    @classmethod
+    def parse_opt(cls, opt):
+        if len(opt) == 0:
+            raise argparse.ArgumentTypeError('blank is not allowed')
+
+        char = opt[0].lower()
+
+        if opt == cls.IMPLICIT_TRUE:
+            return cls(True, False)
+        elif char in ['1', 't']:
+            return cls(True, True)
+        elif char in ['0', 'f']:
+            return cls(False, True)
+        else:
+            raise argparse.ArgumentTypeError(
+                '"%s" is not allowed. Try "true" or "false"' % raw_opt
+            )
 
 # disables
-disable_opts = parser.add_argument_group(
-    "Broad Disable Options",
+broad_opts = parser.add_argument_group(
+    "Broad Options",
     "disable security for entire components. This overrides any more specific "
     "options set from the sections below."
 )
-disable_opts.add_argument(
-    '--disable', action='store_true', default=False,
-    help='disable all security. This overrides everything.'
+broad_opts.add_argument(
+    '--enable', type=ImplicitBool.parse_opt, default=ImplicitBool.IMPLICIT_TRUE,
+    help='enable all security. This overrides everything.'
 )
-disable_opts.add_argument(
-    '--consul', type=bool_opt, default=True,
+broad_opts.add_argument(
+    '--consul', type=ImplicitBool.parse_opt, default=True,
     help='Enable Consul security. This overrides all other Consul options.'
 )
-disable_opts.add_argument(
-    '--mesos', type=bool_opt, default=True,
+broad_opts.add_argument(
+    '--mesos', type=ImplicitBool.parse_opt, default=True,
     help='Enable Mesos security. This overrides all other Mesos options.'
 )
-disable_opts.add_argument(
-    '--marathon', type=bool_opt, default=True,
+broad_opts.add_argument(
+    '--marathon', type=ImplicitBool.parse_opt, default=True,
     help='Enable Marathon security. This overrides all other Marathon options.'
 )
-disable_opts.add_argument(
-    '--iptables', type=bool_opt, default=True,
+broad_opts.add_argument(
+    '--iptables', type=ImplicitBool.parse_opt, default=True,
     help='Use iptables rules. This overrides all other options related to iptables.'
 )
 
@@ -117,17 +143,17 @@ consul_opts = parser.add_argument_group(
     "enable and disable auth components of Consul"
 )
 consul_opts.add_argument(
-    '--consul-auth', type=bool_opt, default=True,
+    '--consul-auth', type=ImplicitBool.parse_opt, default=True,
     help='enable Consul auth',
     dest='do_consul_auth'
 )
 consul_opts.add_argument(
-    '--consul-ssl', type=bool_opt, default=True,
+    '--consul-ssl', type=ImplicitBool.parse_opt, default=True,
     help='enable Consul auth',
     dest='do_consul_ssl',
 )
 consul_opts.add_argument(
-    '--consul-acl', type=bool_opt, default=True,
+    '--consul-acl', type=ImplicitBool.parse_opt, default=True,
     help='enable Consul ACLs',
     dest='do_consul_acl'
 )
@@ -138,27 +164,27 @@ mesos_opts = parser.add_argument_group(
     "enable and disable auth components of Mesos"
 )
 mesos_opts.add_argument(
-    '--mesos-ssl', type=bool_opt,
+    '--mesos-ssl', type=ImplicitBool.parse_opt,
     help='enable Mesos SSL',
     dest='do_mesos_ssl', default=True,
 )
 mesos_opts.add_argument(
-    '--mesos-auth', type=bool_opt,
+    '--mesos-auth', type=ImplicitBool.parse_opt,
     help='enable Mesos authentication',
     dest='do_mesos_auth', default=True,
 )
 mesos_opts.add_argument(
-    '--mesos-framework-auth', type=bool_opt,
+    '--mesos-framework-auth', type=ImplicitBool.parse_opt,
     help='enable Mesos framework authentication',
     dest='do_mesos_framework_auth', default=True,
 )
 mesos_opts.add_argument(
-    '--mesos-follower-auth', type=bool_opt,
+    '--mesos-follower-auth', type=ImplicitBool.parse_opt,
     help='enable Mesos follower authentication',
     dest='do_mesos_follower_auth', default=True,
 )
 mesos_opts.add_argument(
-    '--mesos-iptables', type=bool_opt,
+    '--mesos-iptables', type=ImplicitBool.parse_opt,
     help='enable Mesos iptables rules',
     dest='do_mesos_iptables', default=True,
 )
@@ -169,17 +195,17 @@ marathon_opts = parser.add_argument_group(
     "enable and disable auth components of Marathon"
 )
 marathon_opts.add_argument(
-    '--marathon-ssl', type=bool_opt,
+    '--marathon-ssl', type=ImplicitBool.parse_opt,
     help='enable Marathon SSL',
     dest='do_marathon_ssl', default=True
 )
 marathon_opts.add_argument(
-    '--marathon-auth', type=bool_opt,
+    '--marathon-auth', type=ImplicitBool.parse_opt,
     help='enable Marathon authentication',
     dest='do_marathon_auth', default=True
 )
 marathon_opts.add_argument(
-    '--marathon-iptables', type=bool_opt,
+    '--marathon-iptables', type=ImplicitBool.parse_opt,
     help='enable Marathon iptables rules',
     dest='do_marathon_iptables', default=True
 )
@@ -197,6 +223,10 @@ yaml.SafeDumper.add_representer(
     OrderedDict,
     lambda dumper, od: dumper.represent_dict(od.iteritems())
 )
+yaml.SafeDumper.add_representer(
+    ImplicitBool,
+    ImplicitBool.represent
+)
 
 PASSWORDS = {}  # KV is purpose: password
 
@@ -209,13 +239,11 @@ class Component(object):
         """return tasks which need to be run"""
         return []
 
-    @property
-    def disabled(self):
-        return self.args.disable
-
-    @property
-    def enabled(self):
-        return not self.disabled
+    def component_enabled(self, component):
+        if self.args.enable and self.args.enable.explicit:
+            return True
+        else:
+            return self.args.enable and component
 
     def read_security(self):
         try:
@@ -455,15 +483,11 @@ class Consul(Component):
     def check(self):
         return [self.disable_security, self.gossip_key, self.master_acl_token, self.cert, self.default_acl_policy]
 
-    @property
-    def disabled(self):
-        return self.args.disable or not self.args.consul
-
     def disable_security(self):
         "disable security"
-        self.toggle_boolean('do_consul_auth', self.args.do_consul_auth and self.enabled, True)
-        self.toggle_boolean('do_consul_ssl', self.args.do_consul_ssl and self.enabled, True)
-        self.toggle_boolean('do_consul_acl', self.args.do_consul_acl and self.enabled, True)
+        self.toggle_boolean('do_consul_auth', self.component_enabled(self.args.do_consul_auth), True)
+        self.toggle_boolean('do_consul_ssl', self.component_enabled(self.args.do_consul_ssl), True)
+        self.toggle_boolean('do_consul_acl', self.component_enabled(self.args.do_consul_acl), True)
 
     def gossip_key(self):
         "gossip key"
@@ -501,17 +525,13 @@ class Marathon(Component):
     def check(self):
         return [self.disable_security, self.mesos_auth, self.password]
 
-    @property
-    def disabled(self):
-        return self.args.disable or not self.args.marathon
-
     def disable_security(self):
         "disable security"
-        self.toggle_boolean('do_marathon_auth', self.args.do_marathon_auth and self.enabled, True)
-        self.toggle_boolean('do_marathon_ssl', self.args.do_marathon_ssl and self.enabled, True)
+        self.toggle_boolean('do_marathon_auth', self.component_enabled(self.args.do_marathon_auth), True)
+        self.toggle_boolean('do_marathon_ssl', self.component_enabled(self.args.do_marathon_ssl), True)
         self.toggle_boolean(
             'do_marathon_iptables',
-            self.args.do_marathon_ssl and self.enabled and self.args.iptables,
+            self.component_enabled(self.args.do_marathon_iptables and self.args.iptables),
             True
         )
 
@@ -587,19 +607,15 @@ class Mesos(Component):  # Mesos should always come after any frameworks
     def check(self):
         return [self.disable_security, self.framework_auth, self.follower_auth, self.deprecate]
 
-    @property
-    def disabled(self):
-        return self.args.disable or not self.args.mesos
-
     def disable_security(self):
         "disable security"
-        self.toggle_boolean('do_mesos_ssl', self.args.do_mesos_ssl and self.enabled, True)
-        self.toggle_boolean('do_mesos_auth', self.args.do_mesos_auth and self.enabled, True)
-        self.toggle_boolean('do_mesos_follower_auth', self.args.do_mesos_follower_auth and self.enabled, True)
-        self.toggle_boolean('do_mesos_framework_auth', self.args.do_mesos_framework_auth and self.enabled, True)
+        self.toggle_boolean('do_mesos_ssl', self.component_enabled(self.args.do_mesos_ssl), True)
+        self.toggle_boolean('do_mesos_auth', self.component_enabled(self.args.do_mesos_auth), True)
+        self.toggle_boolean('do_mesos_follower_auth', self.component_enabled(self.args.do_mesos_follower_auth), True)
+        self.toggle_boolean('do_mesos_framework_auth', self.component_enabled(self.args.do_mesos_framework_auth), True)
         self.toggle_boolean(
             'do_mesos_iptables',
-            self.args.do_mesos_framework_auth and self.enabled and self.args.iptables,
+            self.component_enabled(self.args.do_mesos_iptables and self.args.iptables),
             True
         )
 

--- a/security-setup
+++ b/security-setup
@@ -23,80 +23,92 @@ parser = argparse.ArgumentParser(
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 )
 parser.add_argument(
-    '--no-verify-certificates', action='store_true',
-    help='skip verifying certificates'
-)
-parser.add_argument(
     '--change-admin-password', action='store_true',
     help='change admin password'
 )
 
 # certificates
-certs = parser.add_argument_group(
+cert_opts = parser.add_argument_group(
     "SSL Certificate Options",
     "a certificate authority will be set up, and "
     "certificates will be issued using these options",
 )
-certs.add_argument(
+cert_opts.add_argument(
     '--cert-country', default='US',
     help='certificate country'
 )
-certs.add_argument(
+cert_opts.add_argument(
     '--cert-state', default='New York',
     help='certificate state/province'
 )
-certs.add_argument(
+cert_opts.add_argument(
     '--cert-locality', default='Anytown',
     help='certificate locality/city'
 )
-certs.add_argument(
+cert_opts.add_argument(
     '--cert-organization', default='Example Company Inc',
     help='certificate organization'
 )
-certs.add_argument(
+cert_opts.add_argument(
     '--cert-unit', default='Operations',
     help='organizational unit inside of organization',
 )
-certs.add_argument(
+cert_opts.add_argument(
     '--cert-email', default='operations@example.com',
     help='contact email for organizational unit'
 )
-certs.add_argument(
+cert_opts.add_argument(
     '--consul-location', default='consul.service.consul',
     help='internal name for Consul certificate, will be used as common name'
 )
-certs.add_argument(
+cert_opts.add_argument(
     '--nginx-location', default='*.service.consul',
     help='internal name for Nginx proxies, will be used as common name'
 )
+cert_opts.add_argument(
+    '--no-verify-certificates', action='store_true',
+    help='skip verifying certificates as part of setup process'
+)
 
 # Consul authentication
-parser.add_argument('--disable-consul-auth', action='store_false', help='disable consul auth', dest='do_consul_auth', default=None)
-parser.add_argument('--enable-consul-auth', action='store_true', help='enable consul auth', dest='do_consul_auth')
-parser.add_argument('--disable-consul-ssl', action='store_false', help='disable consul ssl', dest='do_consul_ssl', default=None)
-parser.add_argument('--enable-consul-ssl', action='store_true', help='enable consul ssl', dest='do_consul_ssl')
-parser.add_argument('--disable-consul-acl', action='store_false', help='disable consul ACLs', dest='do_consul_acl', default=None)
-parser.add_argument('--enable-consul-acl', action='store_true', help='enable consul ACLs', dest='do_consul_acl')
+consul_opts = parser.add_argument_group(
+    "Consul Options",
+    "enable and disable auth components of Consul"
+)
+consul_opts.add_argument('--disable-consul-auth', action='store_false', help='disable consul auth', dest='do_consul_auth', default=None)
+consul_opts.add_argument('--enable-consul-auth', action='store_true', help='enable consul auth', dest='do_consul_auth')
+consul_opts.add_argument('--disable-consul-ssl', action='store_false', help='disable consul ssl', dest='do_consul_ssl', default=None)
+consul_opts.add_argument('--enable-consul-ssl', action='store_true', help='enable consul ssl', dest='do_consul_ssl')
+consul_opts.add_argument('--disable-consul-acl', action='store_false', help='disable consul ACLs', dest='do_consul_acl', default=None)
+consul_opts.add_argument('--enable-consul-acl', action='store_true', help='enable consul ACLs', dest='do_consul_acl')
 
 # Mesos security
-parser.add_argument('--disable-mesos-ssl', action='store_false', help='disable mesos ssl', dest='do_mesos_ssl', default=None)
-parser.add_argument('--enable-mesos-ssl', action='store_false', help='enable mesos ssl', dest='do_mesos_ssl')
-parser.add_argument('--disable-mesos-auth', action='store_false', help='disable mesos auth', dest='do_mesos_auth', default=None)
-parser.add_argument('--enable-mesos-auth', action='store_false', help='enable mesos auth', dest='do_mesos_auth')
-parser.add_argument('--disable-mesos-framework-auth', action='store_false', help='disable mesos framework auth', dest='do_mesos_framework_auth', default=None)
-parser.add_argument('--enable-mesos-framework-auth', action='store_false', help='enable mesos framework auth', dest='do_mesos_framework_auth')
-parser.add_argument('--disable-mesos-follower-auth', action='store_false', help='disable mesos follower auth', dest='do_mesos_follower_auth', default=None)
-parser.add_argument('--enable-mesos-follower-auth', action='store_false', help='enable mesos follower auth', dest='do_mesos_follower_auth')
-parser.add_argument('--disable-mesos-iptables', action='store_false', help='disable mesos iptables', dest='do_mesos_iptables', default=None)
-parser.add_argument('--enable-mesos-iptables', action='store_false', help='enable mesos iptables', dest='do_mesos_iptables', default=None)
+mesos_opts = parser.add_argument_group(
+    "Mesos Options",
+    "enable and disable auth components of Mesos"
+)
+mesos_opts.add_argument('--disable-mesos-ssl', action='store_false', help='disable mesos ssl', dest='do_mesos_ssl', default=None)
+mesos_opts.add_argument('--enable-mesos-ssl', action='store_false', help='enable mesos ssl', dest='do_mesos_ssl')
+mesos_opts.add_argument('--disable-mesos-auth', action='store_false', help='disable mesos auth', dest='do_mesos_auth', default=None)
+mesos_opts.add_argument('--enable-mesos-auth', action='store_false', help='enable mesos auth', dest='do_mesos_auth')
+mesos_opts.add_argument('--disable-mesos-framework-auth', action='store_false', help='disable mesos framework auth', dest='do_mesos_framework_auth', default=None)
+mesos_opts.add_argument('--enable-mesos-framework-auth', action='store_false', help='enable mesos framework auth', dest='do_mesos_framework_auth')
+mesos_opts.add_argument('--disable-mesos-follower-auth', action='store_false', help='disable mesos follower auth', dest='do_mesos_follower_auth', default=None)
+mesos_opts.add_argument('--enable-mesos-follower-auth', action='store_false', help='enable mesos follower auth', dest='do_mesos_follower_auth')
+mesos_opts.add_argument('--disable-mesos-iptables', action='store_false', help='disable mesos iptables', dest='do_mesos_iptables', default=None)
+mesos_opts.add_argument('--enable-mesos-iptables', action='store_false', help='enable mesos iptables', dest='do_mesos_iptables', default=None)
 
 # Marathon security
-parser.add_argument('--disable-marathon-ssl', action='store_false', help='disable marathon ssl', dest='do_marathon_ssl', default=None)
-parser.add_argument('--enable-marathon-ssl', action='store_false', help='enable marathon ssl', dest='do_marathon_ssl')
-parser.add_argument('--disable-marathon-auth', action='store_false', help='disable marathon auth', dest='do_marathon_auth', default=None)
-parser.add_argument('--enable-marathon-auth', action='store_false', help='enable marathon auth', dest='do_marathon_auth')
-parser.add_argument('--disable-marathon-iptables', action='store_false', help='disable marathon iptables', dest='do_marathon_iptables', default=None)
-parser.add_argument('--enable-marathon-iptables', action='store_false', help='enable marathon iptables', dest='do_marathon_iptables', default=None)
+marathon_opts = parser.add_argument_group(
+    "Marathon Options",
+    "enable and disable auth components of Marathon"
+)
+marathon_opts.add_argument('--disable-marathon-ssl', action='store_false', help='disable marathon ssl', dest='do_marathon_ssl', default=None)
+marathon_opts.add_argument('--enable-marathon-ssl', action='store_false', help='enable marathon ssl', dest='do_marathon_ssl')
+marathon_opts.add_argument('--disable-marathon-auth', action='store_false', help='disable marathon auth', dest='do_marathon_auth', default=None)
+marathon_opts.add_argument('--enable-marathon-auth', action='store_false', help='enable marathon auth', dest='do_marathon_auth')
+marathon_opts.add_argument('--disable-marathon-iptables', action='store_false', help='disable marathon iptables', dest='do_marathon_iptables', default=None)
+marathon_opts.add_argument('--enable-marathon-iptables', action='store_false', help='enable marathon iptables', dest='do_marathon_iptables', default=None)
 
 BASE = posixpath.abspath(posixpath.dirname(__file__)).replace("\\","/")
 SECURITY_FILE = posixpath.join(BASE, 'security.yml')

--- a/security-setup
+++ b/security-setup
@@ -27,6 +27,20 @@ parser.add_argument(
     help='change admin password'
 )
 
+def bool_opt(string):
+    if len(string) == 0:
+        raise argparse.ArgumentTypeError('blank is not allowed')
+
+    char = string[0].lower()
+    if char in ['1', 't']:
+        return True
+    elif char in ['0', 'f']:
+        return False
+    else:
+        raise argparse.ArgumentTypeError(
+            '"%s" is not allowed. Try "true" or "false"' % string
+        )
+
 # certificates
 cert_opts = parser.add_argument_group(
     "SSL Certificate Options",
@@ -75,12 +89,21 @@ consul_opts = parser.add_argument_group(
     "Consul Options",
     "enable and disable auth components of Consul"
 )
-consul_opts.add_argument('--disable-consul-auth', action='store_false', help='disable consul auth', dest='do_consul_auth', default=None)
-consul_opts.add_argument('--enable-consul-auth', action='store_true', help='enable consul auth', dest='do_consul_auth')
-consul_opts.add_argument('--disable-consul-ssl', action='store_false', help='disable consul ssl', dest='do_consul_ssl', default=None)
-consul_opts.add_argument('--enable-consul-ssl', action='store_true', help='enable consul ssl', dest='do_consul_ssl')
-consul_opts.add_argument('--disable-consul-acl', action='store_false', help='disable consul ACLs', dest='do_consul_acl', default=None)
-consul_opts.add_argument('--enable-consul-acl', action='store_true', help='enable consul ACLs', dest='do_consul_acl')
+consul_opts.add_argument(
+    '--consul-auth', type=bool_opt, default=True,
+    help='enable or disable consul auth',
+    dest='do_consul_auth'
+)
+consul_opts.add_argument(
+    '--consul-ssl', type=bool_opt, default=True,
+    help='enable or disable consul auth',
+    dest='do_consul_ssl',
+)
+consul_opts.add_argument(
+    '--consul-acl', type=bool_opt, default=True,
+    help='enable or disable consul ACLs',
+    dest='do_consul_acl'
+)
 
 # Mesos security
 mesos_opts = parser.add_argument_group(


### PR DESCRIPTION
Fixes issues raised in #239, and documented in #247 and #248. Current help string:

```
usage: set up authentication and security for various components

optional arguments:
  -h, --help            show this help message and exit
  --change-admin-password
                        change admin password during this run (default: False)

Broad Disable Options:
  disable security for entire components. This overrides any more specific options set from the sections below.

  --disable             disable all security. This overrides everything. (default: False)
  --consul CONSUL       Enable Consul security. This overrides all other Consul options. (default: True)
  --mesos MESOS         Enable Mesos security. This overrides all other Mesos options. (default: True)
  --marathon MARATHON   Enable Marathon security. This overrides all other Marathon options. (default: True)
  --iptables IPTABLES   Use iptables rules. This overrides all other options related to iptables. (default: True)

SSL Certificate Options:
  a certificate authority will be set up, and certificates will be issued using these options

  --cert-country CERT_COUNTRY
                        certificate country (default: US)
  --cert-state CERT_STATE
                        certificate state/province (default: New York)
  --cert-locality CERT_LOCALITY
                        certificate locality/city (default: Anytown)
  --cert-organization CERT_ORGANIZATION
                        certificate organization (default: Example Company Inc)
  --cert-unit CERT_UNIT
                        organizational unit inside of organization (default: Operations)
  --cert-email CERT_EMAIL
                        contact email for organizational unit (default: operations@example.com)
  --consul-location CONSUL_LOCATION
                        internal name for Consul certificate, will be used as common name (default: consul.service.consul)
  --nginx-location NGINX_LOCATION
                        internal name for Nginx proxies, will be used as common name (default: *.service.consul)
  --no-verify-certificates
                        skip verifying certificates as part of setup process (default: False)

Consul Options:
  enable and disable auth components of Consul

  --consul-auth DO_CONSUL_AUTH
                        enable Consul auth (default: True)
  --consul-ssl DO_CONSUL_SSL
                        enable Consul auth (default: True)
  --consul-acl DO_CONSUL_ACL
                        enable Consul ACLs (default: True)

Mesos Options:
  enable and disable auth components of Mesos

  --mesos-ssl DO_MESOS_SSL
                        enable Mesos SSL (default: True)
  --mesos-auth DO_MESOS_AUTH
                        enable Mesos authentication (default: True)
  --mesos-framework-auth DO_MESOS_FRAMEWORK_AUTH
                        enable Mesos framework authentication (default: True)
  --mesos-follower-auth DO_MESOS_FOLLOWER_AUTH
                        enable Mesos follower authentication (default: True)
  --mesos-iptables DO_MESOS_IPTABLES
                        enable Mesos iptables rules (default: True)

Marathon Options:
  enable and disable auth components of Marathon

  --marathon-ssl DO_MARATHON_SSL
                        enable Marathon SSL (default: True)
  --marathon-auth DO_MARATHON_AUTH
                        enable Marathon authentication (default: True)
  --marathon-iptables DO_MARATHON_IPTABLES
                        enable Marathon iptables rules (default: True)
```