### PR TITLE
Fix #282

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Fixes
 * security-setup now uses proper common names #228
 * serialize consul restarts #262
 * Remove use of sudo for local file modify #272
+* Use ciscocloud data volume for zookeeper #282
 
 0.2.0 (04-10-2015)
 ------------------

--- a/roles/zookeeper/templates/zookeeper-service.j2
+++ b/roles/zookeeper/templates/zookeeper-service.j2
@@ -17,7 +17,7 @@ ExecStartPre=/bin/bash -c ' \
         --name={{ zookeeper_data_volume }} \
         -v /var/lib/zookeeper \
         -v /var/log/zookeeper \
-        tianon/true' 
+        ciscocloud/data-volume'
 
 ExecStart=/usr/bin/docker run \
     --name={{ zookeeper_container_name }} \

--- a/roles/zookeeper/templates/zookeeper-service.j2
+++ b/roles/zookeeper/templates/zookeeper-service.j2
@@ -17,7 +17,7 @@ ExecStartPre=/bin/bash -c ' \
         --name={{ zookeeper_data_volume }} \
         -v /var/lib/zookeeper \
         -v /var/log/zookeeper \
-        ciscocloud/data-volume'
+        ciscocloud/data-volume:0.1'
 
 ExecStart=/usr/bin/docker run \
     --name={{ zookeeper_container_name }} \


### PR DESCRIPTION
tianon/true was failing to work with docker 1.6.0, so we're using a home-grown container that has the /tmp filesystem.