### PR TITLE
Move flush-hanlders after script installations

### DIFF
--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -57,8 +57,6 @@
   tags:
     - consul
 
-- meta: flush_handlers
-
 - name: install consul script
   sudo: yes
   copy:
@@ -87,6 +85,8 @@
   command: consul-wait-for-leader.sh
   tags:
     - consul
+
+- meta: flush_handlers
 
 - include: acl.yml
   when: do_consul_acl


### PR DESCRIPTION
This is to prevent the restart handler kicking off
before the scripts they use are installed.