### PR TITLE
[FEATURE] Add metadata to hosts in Openstack

### DIFF
--- a/inventory/group_vars/dc1
+++ b/inventory/group_vars/dc1
@@ -2,6 +2,9 @@
 # os_tenant_name: tenant-name
 # os_tenant_id: 86e97371ad71450d91b292029ca9a8c2
 # os_net_id: e7b1ae4f-e0d2-4e24-a48f-b9e6c4933323
+# host_metadata:
+#  - group: controllers
+#  - key: value
 
 os_auth_url:
 os_tenant_name:
@@ -9,3 +12,4 @@ os_tenant_id:
 os_net_id:
 consul_dc: dc1
 security_group: default
+host_metadata:

--- a/inventory/group_vars/dc2
+++ b/inventory/group_vars/dc2
@@ -2,6 +2,9 @@
 # os_tenant_name: tenant-name
 # os_tenant_id: 86e97371ad71450d91a48f029ca9a8c2
 # os_net_id: b7b0ae4f-e0d2-4e24-a48f-b9e6c4921423
+# host_metadata:
+#  - group: controllers
+#  - key: value
 
 os_auth_url:
 os_tenant_name:
@@ -9,3 +12,4 @@ os_tenant_id:
 os_net_id:
 consul_dc: dc2
 security_group: default
+host_metadata:

--- a/openstack/provision-hosts.yml
+++ b/openstack/provision-hosts.yml
@@ -21,6 +21,7 @@
           - net-id: "{{ os_net_id }}"
         security_groups: "{{ security_group }}"
         state: "{{ nova_compute_state }}"
+        meta: "{{ host_metadata }}"
       always_run: yes
       register: host
       tags: host

--- a/openstack/provision-hosts.yml
+++ b/openstack/provision-hosts.yml
@@ -21,7 +21,7 @@
           - net-id: "{{ os_net_id }}"
         security_groups: "{{ security_group }}"
         state: "{{ nova_compute_state }}"
-        meta: "{{ host_metadata }}"
+        meta: "{{ host_metadata | default() }}"
       always_run: yes
       register: host
       tags: host


### PR DESCRIPTION
Provide the ability to add metadata key/value pairs to hosts within
Openstack.

Use Case:
	Deploy applications to hosts with ansible using inventory plugin that can
	query hosts via novaclient and be grouped based on attributes within the
	hosts metadata.