### PR TITLE
Fix for "install nginx admin password" task in consul role

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -21,8 +21,17 @@
     - docker
     - dnsmasq
     - nginx
-    - consul
     - logstash
+
+- hosts: dc1
+  gather_facts: no
+  roles:
+    - consul
+    
+- hosts: dc2
+  gather_facts: no
+  roles:
+    - consul 
 
 - include: playbooks/consul-join-wan.yml
 


### PR DESCRIPTION
In multi-datacenter deployment task "install nginx admin password" from
consul role should run on both datacenters, but only once, so the task
itself has a flag "run_once" and we separate consul deployment to 2
datacenters