### PR TITLE
[BUGFIX] ansible nova_compute module bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=1.9
+ansible==1.9.0.1
 python-novaclient>=2.23.0
 python-keystoneclient
 Sphinx==1.2.3


### PR DESCRIPTION
There was a bug introduced during 1.9 as plan is to deprecate the
module in favor of a new module. The output from the server state
returns back the ip addresses as list instead of strings.
A fix was applied such that 1.9.0.1 returns a string as expected.

By capping the version of ansible to 1.9.0.1, then any openstack
related playbooks will work normally.

See issue #316 for additional details.