### PR TITLE
Add basic Kafka utility to the slaves

### DIFF
--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -2,7 +2,7 @@
 kafka_install_dir: "/usr/local/share/kafka"
 kafka_mesos_install_dir: "/usr/local/share/kafka-mesos"
 kafka_binary_url: "https://archive.apache.org/dist/kafka/0.8.1.1"
-kafka_archive: "kafka_2.9.2-0.8.1.1.tgz"
+kafka_archive: "kafka_2.9.2-0.8.1.1"
 kafka_mesos_repo: "https://github.com/mesos/kafka"
 mesos_lib: "/usr/local/lib/libmesos.so"
 zookeeper_master: "zookeeper.service.consul"

--- a/roles/kafka/tasks/client.yml
+++ b/roles/kafka/tasks/client.yml
@@ -35,10 +35,10 @@
   tags:
     - kafka
 
-# - name: Install basic Kafka client  
-#   sudo: true
-#   command: "./sbt update; ./sbt package"
-#   args:
-#     chdir: "{{ kafka_install_dir }}"
-#   tags:
-#     - kafka
+- name: Install basic Kafka client  
+  sudo: true
+  command: "./sbt update; ./sbt package"
+  args:
+    chdir: "{{ kafka_install_dir }}/{{ kafka_archive }}"
+  tags:
+    - kafka

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -12,6 +12,7 @@
   git: 
     repo: "{{ kafka_mesos_repo }}" 
     dest: "{{ kafka_mesos_install_dir }}"
+    force: yes
   tags:
     - kafka
 
@@ -27,28 +28,28 @@
 - name: Download Kafka binary
   sudo: true 
   get_url: 
-    url: "{{ kafka_binary_url }}/{{ kafka_archive }}"
+    url: "{{ kafka_binary_url }}/{{ kafka_archive }}.tgz"
     dest: "{{ kafka_mesos_install_dir }}"
   register: kafka_downloaded
   tags:
     - kafka 
 
-#- name: Create Kafka directory
-#  sudo: true
-#  file: 
-#    path: "{{ kafka_install_dir }}"
-#    state: directory
-#  tags:
-#    - kafka
+- name: Create Kafka directory
+  sudo: true
+  file: 
+    path: "{{ kafka_install_dir }}"
+    state: directory
+  tags:
+    - kafka
 
-#- name: Setup Kafka binary
-#  sudo: true
-#  unarchive:
-#    src: "{{ kafka_mesos_install_dir }}/{{ kafka_archive }}"
-#    dest: "{{ kafka_install_dir }}"
-#    copy: no
-#  tags:
-#    - kafka
+- name: Setup Kafka binary
+  sudo: true
+  unarchive:
+    src: "{{ kafka_mesos_install_dir }}/{{ kafka_archive }}.tgz"
+    dest: "{{ kafka_install_dir }}"
+    copy: no
+  tags:
+    - kafka
 
 - name: Setup Kafka environment
   sudo: true

--- a/roles/kafka/templates/kafka.sh.j2
+++ b/roles/kafka/templates/kafka.sh.j2
@@ -1,2 +1,1 @@
-export PATH=$PATH:{{ kafka_mesos_install_dir }}
-export CLASSPATH=$CLASSPATH:{{ kafka_mesos_install_dir }}
+export PATH=$PATH:{{ kafka_mesos_install_dir }}:{{ kafka_install_dir }}/{{ kafka_archive }}/bin


### PR DESCRIPTION
- Put binary into /usr/local/share/kafka
- Set $PATH so all kafka utility will be working out of the box
- Missed feature: utility should use --zookeeper parameter to
define where is master Zookeeper (zookeeper.service.consul)

FeatureID: NONE