### PR TITLE
Feature/frameworks

### DIFF
--- a/roles/kafka/README.md
+++ b/roles/kafka/README.md
@@ -6,8 +6,9 @@
 
 - `kafka_install_dir`: define folder for kafka installation. Default `/usr/local/share/kafka`
 - `kafka_mesos_install_dir` define folder for kafka-mesos installation. Default `/usr/local/share/kafka-mesos`
-- `kafka_binary_url`: define URL for kafka binary installation. Default: https://archive.apache.org/dist/kafka/0.8.1.1/
-- `kafka_archive`: kafka archive name. Default:  kafka_2.9.2-0.8.1.1.tgz
+- `kafka_binary_url`: define URL for kafka binary installation. Default: https://archive.apache.org/dist/kafka/
+- `kafka_version`: specify version of kafka that will be used. Default: "0.8.2.1"
+- `kafka_scala_version`: version of scala. Default: "2.10"
 - `kafka_mesos_repo`: mesos-kafka repo URL. Default: https://github.com/mesos/kafka
 - `mesos_lib`: Specify mesos library location. Default: `/usr/local/lib/libmesos.so`
 - `zookeeper_master`: Specify FQDN for zookeeper master. Default for MI project is `zookeeper.service.consul`

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -2,7 +2,7 @@
 kafka_install_dir: "/usr/local/share/kafka"
 kafka_mesos_install_dir: "/usr/local/share/kafka-mesos"
 kafka_binary_url: "https://archive.apache.org/dist/kafka/0.8.1.1"
-kafka_archive: "kafka_2.9.2-0.8.1.1.tgz"
+kafka_archive: "kafka_2.9.2-0.8.1.1"
 kafka_mesos_repo: "https://github.com/mesos/kafka"
 mesos_lib: "/usr/local/lib/libmesos.so"
 zookeeper_master: "zookeeper.service.consul"

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
 kafka_install_dir: "/usr/local/share/kafka"
 kafka_mesos_install_dir: "/usr/local/share/kafka-mesos"
-kafka_binary_url: "https://archive.apache.org/dist/kafka/0.8.1.1"
-kafka_archive: "kafka_2.9.2-0.8.1.1"
+kafka_binary_url: "https://archive.apache.org/dist/kafka"
+kafka_version: "0.8.2.1"
+kafka_scala_version: "2.10"
 kafka_mesos_repo: "https://github.com/mesos/kafka"
 mesos_lib: "/usr/local/lib/libmesos.so"
 zookeeper_master: "zookeeper.service.consul"

--- a/roles/kafka/tasks/client.yml
+++ b/roles/kafka/tasks/client.yml
@@ -35,10 +35,10 @@
   tags:
     - kafka
 
-# - name: Install basic Kafka client  
-#   sudo: true
-#   command: "./sbt update; ./sbt package"
-#   args:
-#     chdir: "{{ kafka_install_dir }}"
-#   tags:
-#     - kafka
+- name: Install basic Kafka client  
+  sudo: true
+  command: "./sbt update; ./sbt package"
+  args:
+    chdir: "{{ kafka_install_dir }}/{{ kafka_archive }}"
+  tags:
+    - kafka

--- a/roles/kafka/tasks/client.yml
+++ b/roles/kafka/tasks/client.yml
@@ -4,8 +4,7 @@
   wait_for: 
     host: "{{ ansible_hostname }}"
     port: 7000 
-    delay: 10
-    timeout: 300
+    delay: 30
   tags:
     - kafka
 
@@ -24,21 +23,5 @@
   command: "./kafka-mesos.sh start 0..{{ kafka_brokers - 1 }} --api http://{{ ansible_hostname }}:7000"
   args:
     chdir: "{{ kafka_mesos_install_dir }}"
-  tags:
-    - kafka
-
-- name: Create Kafka-Mesos configuration
-  sudo: true
-  template:
-    src: "kafka.properties.j2"
-    dest: "{{ kafka_mesos_install_dir }}/kafka-mesos.properties"
-  tags:
-    - kafka
-
-- name: Install basic Kafka client  
-  sudo: true
-  command: "./sbt update; ./sbt package"
-  args:
-    chdir: "{{ kafka_install_dir }}/{{ kafka_archive }}"
   tags:
     - kafka

--- a/roles/kafka/tasks/config.yml
+++ b/roles/kafka/tasks/config.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Setup Kafka environment
+  sudo: true
+  template:
+    src: "kafka.sh.j2"
+    dest: "/etc/profile.d/kafka.sh"
+  tags:
+    - kafka
+
+- name: Create Kafka-Mesos configuration
+  sudo: true
+  template:
+    src: "kafka.properties.j2"
+    dest: "{{ kafka_mesos_install_dir }}/kafka-mesos.properties"
+  tags:
+    - kafka

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: Download Kafka binary
   sudo: true 
   get_url: 
-    url: "{{ kafka_binary_url }}/{{ kafka_archive }}.tgz"
+    url: "{{ kafka_binary_url }}/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz"
     dest: "{{ kafka_mesos_install_dir }}"
   register: kafka_downloaded
   tags:
@@ -38,24 +38,16 @@
   sudo: true
   file: 
     path: "{{ kafka_install_dir }}"
+    owner: "{{ ansible_user_id }}"
     state: directory
   tags:
     - kafka
 
 - name: Setup Kafka binary
-  sudo: true
   unarchive:
-    src: "{{ kafka_mesos_install_dir }}/{{ kafka_archive }}.tgz"
+    src: "{{ kafka_mesos_install_dir }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz"
     dest: "{{ kafka_install_dir }}"
     copy: no
-  tags:
-    - kafka
-
-- name: Setup Kafka environment
-  sudo: true
-  template:
-    src: "kafka.sh.j2"
-    dest: "/etc/profile.d/kafka.sh"
   tags:
     - kafka
 
@@ -64,3 +56,5 @@
 
 - include: client.yml
   when: kafka_downloaded | changed
+
+- include: config.yml

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -12,6 +12,7 @@
   git: 
     repo: "{{ kafka_mesos_repo }}" 
     dest: "{{ kafka_mesos_install_dir }}"
+    force: yes
   tags:
     - kafka
 
@@ -27,28 +28,28 @@
 - name: Download Kafka binary
   sudo: true 
   get_url: 
-    url: "{{ kafka_binary_url }}/{{ kafka_archive }}"
+    url: "{{ kafka_binary_url }}/{{ kafka_archive }}.tgz"
     dest: "{{ kafka_mesos_install_dir }}"
   register: kafka_downloaded
   tags:
     - kafka 
 
-#- name: Create Kafka directory
-#  sudo: true
-#  file: 
-#    path: "{{ kafka_install_dir }}"
-#    state: directory
-#  tags:
-#    - kafka
+- name: Create Kafka directory
+  sudo: true
+  file: 
+    path: "{{ kafka_install_dir }}"
+    state: directory
+  tags:
+    - kafka
 
-#- name: Setup Kafka binary
-#  sudo: true
-#  unarchive:
-#    src: "{{ kafka_mesos_install_dir }}/{{ kafka_archive }}"
-#    dest: "{{ kafka_install_dir }}"
-#    copy: no
-#  tags:
-#    - kafka
+- name: Setup Kafka binary
+  sudo: true
+  unarchive:
+    src: "{{ kafka_mesos_install_dir }}/{{ kafka_archive }}.tgz"
+    dest: "{{ kafka_install_dir }}"
+    copy: no
+  tags:
+    - kafka
 
 - name: Setup Kafka environment
   sudo: true

--- a/roles/kafka/templates/kafka.sh.j2
+++ b/roles/kafka/templates/kafka.sh.j2
@@ -1,2 +1,1 @@
-export PATH=$PATH:{{ kafka_mesos_install_dir }}
-export CLASSPATH=$CLASSPATH:{{ kafka_mesos_install_dir }}
+export PATH=$PATH:{{ kafka_mesos_install_dir }}:{{ kafka_install_dir }}/{{ kafka_archive }}/bin

--- a/roles/kafka/templates/kafka.sh.j2
+++ b/roles/kafka/templates/kafka.sh.j2
@@ -1,1 +1,1 @@
-export PATH=$PATH:{{ kafka_mesos_install_dir }}:{{ kafka_install_dir }}/{{ kafka_archive }}/bin
+export PATH=$PATH:{{ kafka_mesos_install_dir }}:{{ kafka_install_dir }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}/bin


### PR DESCRIPTION
 Basic improvements:

 - add kafka_version and kafka_scala_version to default to be able
    with version without rewriting code (redeploy from the scratch
    still required)
 - install basic kafka utility: kafka-topics.sh,
    kafka-console-consumer.sh, kafka-console-producer.sh etc.

Issues fixes:

- client mesos-kafka.sh will be waiting till mesos-kafka-scheduler
     will be available without timeout  (till success)
- Kafka config will be applied in the end every run to avoid
    misconfiguration

Notes:

- utility kafka-mesos.sh can be runing just in it install folder.
     That how this script is working so if you not in instal dir (/usr/local/share/kafka-mesos) it will rise error that appropriate jar can’t be found
- for basic kafka utility get some endpoint like host-05:4001 from
    "kafka-mesos.sh status" list
