### PR TITLE
Change default memory values for Kafka brokers

### DIFF
--- a/roles/kafka/README.md
+++ b/roles/kafka/README.md
@@ -15,8 +15,8 @@
 - `marathon`: Specify FQDN for marathon services. Default for MI project is `marathon.service.consul`
 - `kafka_scheduler_hostname`: hostname of kafka mesos scheduler. Default: `kafka-mesos-scheduler.service.consul`
 - `kafka_brokers`: Define number of brokers that will be used in your cluster. Default: 3
-- `kafka_broker_memory`: Specify Java memory setting for broker. Default: 2048
-- `kafka_broker_heap`: Specify Java heap for broker. Default: 1024 
+- `kafka_broker_memory`: Specify Java memory setting for broker. Default: 512
+- `kafka_broker_heap`: Specify Java heap for broker. Default: 256 
 - `debug_enabled`: enable or dissable debug mode for kafka-mesos. Default: false
 
 ## Example Playbook

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -10,6 +10,6 @@ zookeeper_master: "zookeeper.service.consul"
 marathon: "marathon.service.consul"
 kafka_scheduler_hostname: "kafka-mesos-scheduler.service.consul"
 kafka_brokers: 3
-kafka_broker_memory: 2048
-kafka_broker_heap: 1024 
+kafka_broker_memory: 512
+kafka_broker_heap: 256 
 debug_enabled: false


### PR DESCRIPTION
For small cluster change kafka_memory and kafka_heap value from
2048 and 1024 to 512 and 256

FeatureID: Internal