### PR TITLE
manage DNS with dnsmasq alone

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+use_host_domain: false
+host_domain: novalocal

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -13,8 +13,8 @@
   sudo: yes
   lineinfile:
     dest: /etc/hosts
-    regexp: "^{{ hostvars[item].ansible_default_ipv4.address }} {{ item }} {{ item }}.novalocal$"
-    line: "{{ hostvars[item].ansible_default_ipv4.address }} {{ item }} {{ item }}.novalocal"
+    regexp: "^{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}{% if use_host_domain %} {{ item }}.{{ host_domain }}{% endif %}$"
+    line: "{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}{% if use_host_domain %} {{ item }}.{{ host_domain}}{% endif %}"
     state: present
   when: hostvars[item].ansible_default_ipv4.address is defined
   with_items: groups['all']

--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -1,9 +1,8 @@
 ---
-# We disble dnsmasq in systemd so that NetworkManager can control it
-- name: disable dnsmasq
-  sudo: yes
-  command: systemctl disable dnsmasq
-
 - name: restart networkmanager
   sudo: yes
   command: systemctl restart NetworkManager
+
+- name: restart dnsmasq
+  sudo: yes
+  command: systemctl restart dnsmasq

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -23,8 +23,19 @@
   sudo: yes
   template: 
     src: 10-consul 
-    dest: /etc/NetworkManager/dnsmasq.d/10-consul
+    dest: /etc/dnsmasq.d/10-consul
     mode: 755
+  notify:
+    - restart dnsmasq
+  tags:
+    - dnsmasq
+
+- name: enable dnsmasq
+  sudo: yes
+  service:
+    name: dnsmasq
+    state: started
+    enabled: yes
   tags:
     - dnsmasq
 
@@ -32,10 +43,19 @@
   sudo: yes
   lineinfile:
     dest: /etc/NetworkManager/NetworkManager.conf
-    line: "dns=dnsmasq"
-    insertbefore: "^plugins"
+    line: "dns=none"
+    insertafter: "^\\[main\\]$"
   notify:
     - restart networkmanager
+  tags:
+    - dnsmasq
+
+- name: add dnsmasq to /etc/resolv.conf
+  sudo: yes
+  lineinfile:
+    dest: /etc/resolv.conf
+    line: "search {{ consul_dns_domain }}\nnameserver 127.0.0.1"
+    insertbefore: BOF
   tags:
     - dnsmasq
 


### PR DESCRIPTION
Previously:

 - NetworkManager would manage DNS via dnsmasq
 - if interfaces were brought up with cloud-init (as on GCE) NetworkManager would not start the dnsmasq instance. Additionally, if dnsmasq died NetworkManager would not necessarily restart it.
 - NetworkManager would overwrite `/etc/resolv.conf`

Now:

 - dnsmasq is managed by systemd, which will keep it alive
 - NetworkManager's DNS settings are disabled
 - the default DNS servers are used for domains other than `consul_dns_domain`, since we can specify separate search settings.

I'd appreciate if someone could test this on OpenStack and another Vagrant machine. I've already tested that the `/etc/resolv.conf` will survive across changing the hostname via `nmcli gen hostname {new name}` and rebooting, two instances in which NM would previously overwrite our custom config.