### PR TITLE
Workaround for Vagrant < 1.7.3 and host with > 5 ssh-keys

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,6 +41,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "ansible" do |ansible|
+    ansible.raw_ssh_args = ['-o IdentitiesOnly=yes']
     ansible.extra_vars = { ansible_ssh_user: 'vagrant' }
     ansible.playbook = "vagrant.yml"
     ansible.groups = {


### PR DESCRIPTION
On systems with more than 5 ssh-keys added, ansible provisioner will fail with:
```
PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_HOST_KEY_CHECKING=false ANSIBLE_SSH_ARGS='-o UserKnownHostsFile=/dev/null -o ControlMaster=auto -o ControlPersist=60s' ansible-playbook --private-key=/Users/adam/workspace/microservices-infrastructure/.vagrant/machines/default/virtualbox/private_key --user=vagrant --connection=ssh --limit='default' --inventory-file=/Users/adam/workspace/microservices-infrastructure/.vagrant/provisioners/ansible/inventory --extra-vars={"consul_acl_agent_token":"64f3ecc3-82e1-47e6-82a9-88be854a6d1c","consul_acl_master_token":"66569297-caf6-480f-a87d-41f65b5dc71a","consul_default_acl_policy":"allow","consul_gossip_key":"IVVoL8KWLPs73sFG82RSVA==","do_consul_acl":true,"do_consul_auth":true,"do_consul_ssl":true,"do_marathon_auth":true,"do_marathon_iptables":true,"do_marathon_ssl":true,"do_mesos_auth":true,"do_mesos_follower_auth":true,"do_mesos_framework_auth":true,"do_mesos_iptables":true,"do_mesos_ssl":true,"marathon_http_credentials":"admin:mehere","marathon_principal":"marathon","marathon_secret":"zy1C6Udp4qce8KWN99bmKFqdtl9vaS2hSgs9Hc3jSKlv","mesos_credentials":[{"principal":"marathon","secret":"zy1C6Udp4qce8KWN99bmKFqdtl9vaS2hSgs9Hc3jSKlv"}],"mesos_follower_principal":"follower","mesos_follower_secret":"x1ZxSRtI1qMvMDg6OBzLpFjNkEb3w9qEcOu+uqnbEi06","nginx_admin_password":"mehere","security_enabled":true,"zk_marathon_user":"marathon","zk_marathon_user_secret":"GGH2ZeqyAYM0RBwn","zk_marathon_user_secret_digest":"nX9PhnXWcTYF4uqzLaKjGYU40mI=","zk_mesos_user":"mesos","zk_mesos_user_secret":"OGeNRV9qkfLKkadA","zk_mesos_user_secret_digest":"o9AaHJNgOby2uJxA6WT96SfArnI=","zk_super_user":"super","zk_super_user_secret":"ZygfO+gxEjLsDzcrDNAvUveurDXy/Czg/flYnigzTo3E","consul_servers_group":"consul_servers","consul_dns_domain":"consul","consul_dc":"vagrant","consul_acl_datacenter":"vagrant","consul_bootstrap_expect":1,"mesos_cluster":"vagrant","mesos_mode":"mixed"} vagrant.yml

PLAY [all] ********************************************************************

GATHERING FACTS ***************************************************************
fatal: [default] => SSH Error: Received disconnect from 127.0.0.1: 2: Too many authentication failures for vagrant
    while connecting to 127.0.0.1:2222
It is sometimes useful to re-run the command using -vvvv, which prints SSH debug output to help diagnose the issue.

TASK: [common | set timezone to etc/utc] **************************************
FATAL: no hosts matched or all hosts have already failed -- aborting
```

Setting the ssh option IdentitiesOnly will correct this and is resolved upstream in Vagrant 1.7.3:
https://github.com/mitchellh/vagrant/commit/c3cae3d235defe4bf42ad05eb93a651c8f83b7f2