### PR TITLE
Kafka depploy is failing because connection timeout

### DIFF
--- a/roles/kafka/tasks/client.yml
+++ b/roles/kafka/tasks/client.yml
@@ -4,6 +4,7 @@
   wait_for: 
     host: "{{ ansible_hostname }}"
     port: 7000 
+    timeout: 900
     delay: 30
   tags:
     - kafka


### PR DESCRIPTION
Issue: Timeout when waiting for host-04:7000
In case slow network or some performance issue kafka-sheduler need
more than 300 sec (default for wait_for ansible module) to be
deployed on top of marathon.

Change "timeout" value to 900 that increase maximum number of
seconds to wait for Kafka-sheduler

IssueID: INTERNAL