### PR TITLE
added openssh to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.1
 
-RUN apk add --update openssl python py-pip \
+RUN apk add --update openssh openssl python py-pip \
     && rm -rf /var/cache/apk/*
 
 # load microservices-infrastructure and default setup


### PR DESCRIPTION
Dockerfile is missing `openssh`

After doing a complete build using the Dockerfile base image, that was the only change I had to make.