### PR TITLE
Enable log4j for Spark

### DIFF
--- a/roles/spark/README.md
+++ b/roles/spark/README.md
@@ -16,6 +16,8 @@ graph processing.
   `/usr/local/lib/libmesos.so`).
 - `zookeeper_master` - Hostname of Zookeeper master (default:
   `zookeeper.service.consul`).
+- `spark_log4j_host` - Hostname for logstash server (default: localhost)
+- `spark_log4j_port` - Port for logstash server (default: 4560)
 
 ## Example Playbook
 

--- a/roles/spark/README.md
+++ b/roles/spark/README.md
@@ -16,8 +16,8 @@ graph processing.
   `/usr/local/lib/libmesos.so`).
 - `zookeeper_master` - Hostname of Zookeeper master (default:
   `zookeeper.service.consul`).
-- `spark_log4j_host` - Hostname for logstash server (default: localhost)
-- `spark_log4j_port` - Port for logstash server (default: 4560)
+- `spark_log4j_host` - Hostname for logstash server (default: `localhost`).
+- `spark_log4j_port` - Port for logstash server (default: `4560`).
 
 ## Example Playbook
 

--- a/roles/spark/defaults/main.yml
+++ b/roles/spark/defaults/main.yml
@@ -5,3 +5,5 @@ spark_user: "centos"
 spark_install_dir: "/usr/local/share/spark"
 spark_mesos_lib: "/usr/local/lib/libmesos.so"
 zookeeper_master: "zookeeper.service.consul"
+spark_log4j_host: localhost
+spark_log4j_port: 4560

--- a/roles/spark/tasks/client.yml
+++ b/roles/spark/tasks/client.yml
@@ -33,3 +33,13 @@
   command: cp {{ spark_install_dir }}/spark-{{ spark_default_version }}-bin-hadoop{{ spark_default_version < '1.3.1' and '2.4' or '2.6' }}/conf/spark-env.sh /etc/profile.d/spark-env.sh
   tags:
     - spark
+
+- name: Setup Spark log4j properties file
+  sudo: true
+  template:
+    src: "log4j.properties.j2"
+    dest: "{{ spark_install_dir }}/spark-{{ item }}-bin-hadoop{{ item < '1.3.1' and '2.4' or '2.6' }}/conf/log4j.properties"
+    mode: 0775
+  with_items: spark_versions
+  tags:
+    - spark

--- a/roles/spark/templates/log4j.properties.j2
+++ b/roles/spark/templates/log4j.properties.j2
@@ -1,0 +1,4 @@
+log4j.rootCategory=INFO, S
+log4j.appender.S=org.apache.log4j.net.SocketAppender
+log4j.appender.S.port={{ spark_log4j_port }}
+log4j.appender.S.remoteHost={{ spark_log4j_host }}

--- a/roles/spark/templates/spark-env.sh.j2
+++ b/roles/spark/templates/spark-env.sh.j2
@@ -1,4 +1,5 @@
 export MESOS_NATIVE_JAVA_LIBRARY={{ spark_mesos_lib }}
 export SPARK_EXECUTOR_URI="file://{{ spark_install_dir }}/spark-{{ item }}-bin-hadoop{{ item < '1.3.1' and '2.4' or '2.6' }}.tgz" 
+export SPARK_HOME="{{ spark_install_dir }}/spark-{{ item }}-bin-hadoop{{ item < '1.3.1' and '2.4' or '2.6' }}"
 export MASTER="mesos://zk://{{ zookeeper_master }}:2181/mesos"
 export PATH={{ spark_install_dir }}/spark-{{ item }}-bin-hadoop{{ item < '1.3.1' and '2.4' or '2.6' }}/bin:$PATH


### PR DESCRIPTION
Setup and configure spark log4j
- add global variable SPARK_HOME to specify spark config directory
- add spark_log4j_host and spark_log4j_port defaults to set log
server hostname and port

FeatureID: INTERNAL