### PR TITLE
Change Logstash syslog plugin port to TCP

### DIFF
--- a/roles/logstash/templates/logstash-service.j2
+++ b/roles/logstash/templates/logstash-service.j2
@@ -16,7 +16,7 @@ ExecStart=/usr/bin/docker run \
     --rm \
     --name=logstash \
     --privileged=true \
-    --publish=1514:1514/udp \
+    --publish=1514:1514 \
     --publish=25826:25826/udp \
     --publish=8125:8125/udp \
 {% if logstash_input_log4j %}


### PR DESCRIPTION
Since we use `@@localhost:1514` to forward logs with rsyslog, we need to set the correct transport protocol in the systemd unit file.