### PR TITLE
Added note on Ansible Python versions

### DIFF
--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -37,6 +37,12 @@ certificates. For more information, see the :doc:`security-setup
 Deploying software via Ansible
 ------------------------------
 
+.. note:: Ansible requres a Python 2 binary. If yours is not at /usr/bin/python,
+          please view the `Ansible FAQ <http://docs.ansible.com/faq.html>`_. You
+          can probably add an extra variable to the following commands,
+          e.g. ``ansible -e ansible_python_interpreter=/path/to/python2``.
+
+
 In the following examples, we're going to assume you deployed hosts using
 ``inventory/1-datacenter``.
 
@@ -44,9 +50,9 @@ First, ping the servers to ensure they are reachable via ssh:
 
 .. code-block:: shell
 
- ansible all -i inventory/1-datacenter -m ping 
+ ansible all -i inventory/1-datacenter -m ping
 
-If any servers fail to connect, check your connection by adding ``-vvvv`` 
+If any servers fail to connect, check your connection by adding ``-vvvv``
 for verbose SSH debugging and try again to view the errors in more detail.
 
 Next, deploy the software
@@ -55,7 +61,7 @@ Next, deploy the software
 
   ansible-playbook -i inventory/1-datacenter site.yml
 
-The deployment will probably take a while as all tasks are completed. 
+The deployment will probably take a while as all tasks are completed.
 
 
 Checking your deployment
@@ -83,8 +89,8 @@ Below are guides to customizing your host inventory, Ansible playbooks and addin
 
    inventory.rst
    playbook.rst
-   ssh_users.rst  
-        
+   ssh_users.rst
+
 .. _generated dynamically: http://docs.ansible.com/intro_dynamic_inventory.html
 .. _inventory file: http://docs.ansible.com/intro_inventory.html
 .. _playbook: http://docs.ansible.com/playbooks.html
@@ -96,7 +102,7 @@ Restarting your deployment
 To restart your deployment and make sure all components are restarted and working correctly, it is recommended to leverage the
 ``playbooks/reboot-hosts.yml`` playbook.
 
-.. code-block:: shell 
+.. code-block:: shell
 
     ansible-playbook -i inventory/1-datacenter playbooks/reboot-hosts.yml
 

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -39,8 +39,8 @@ Deploying software via Ansible
 
 .. note:: Ansible requres a Python 2 binary. If yours is not at /usr/bin/python,
           please view the `Ansible FAQ <http://docs.ansible.com/faq.html>`_. You
-          can probably add an extra variable to the following commands,
-          e.g. ``ansible -e ansible_python_interpreter=/path/to/python2``.
+          can add an extra variable to the following commands, e.g.
+          ``ansible -e ansible_python_interpreter=/path/to/python2``.
 
 
 In the following examples, we're going to assume you deployed hosts using


### PR DESCRIPTION
In case users run OSes like Arch that have Python3 defaults.

Looks like vim also deleted whitespace at the end of a few lines. 