### PR TITLE
Remove ansible openstack playbook dependency

### DIFF
--- a/playbooks/reboot-hosts.yml
+++ b/playbooks/reboot-hosts.yml
@@ -1,6 +1,4 @@
 ---
-- include: ../openstack/provision-hosts.yml
-
 - hosts: all
   serial: 1
   gather_facts: no


### PR DESCRIPTION
Use terraform dynamic inventory instead of ansible openstack inventory. 