### PR TITLE
Add command line argument for hostname to zookeeper-wait-for-listen.sh

### DIFF
--- a/roles/zookeeper/files/zookeeper-wait-for-listen.sh
+++ b/roles/zookeeper/files/zookeeper-wait-for-listen.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+[[ -n "$1" ]] && host=$1 || host=$HOSTNAME
+
 MAX_SECONDS=60
 while /bin/true
 do
-    [[ "$(echo ruok | nc "$HOSTNAME" 2181 2>/dev/null)" == "imok" ]] && exit 0 || sleep 1
+    [[ "$(echo ruok | nc "$host" 2181 2>/dev/null)" == "imok" ]] && exit 0 || sleep 1
     [[ "$SECONDS" -ge "$MAX_SECONDS" ]] && exit 1
 done
 

--- a/roles/zookeeper/handlers/main.yml
+++ b/roles/zookeeper/handlers/main.yml
@@ -25,4 +25,4 @@
     - zookeeper
 
 - name: wait for zookeeper to listen
-  command: /usr/local/bin/zookeeper-wait-for-listen.sh
+  command: "/usr/local/bin/zookeeper-wait-for-listen.sh {{ inventory_hostname }}"


### PR DESCRIPTION
When ansible runs in vagrant the $HOSTNAME variable has localhost.localdomain.