### PR TITLE
Added OpenConnect VPN role

### DIFF
--- a/docs/components/opeconnect.rst
+++ b/docs/components/opeconnect.rst
@@ -1,0 +1,1 @@
+.. include:: ../../roles/openconnect/README.rst

--- a/inventory/1-datacenter
+++ b/inventory/1-datacenter
@@ -43,3 +43,6 @@ host-[04:05]
 
 [kafka]
 host-[04:05]
+
+[vpn_servers]
+host-02

--- a/inventory/2-datacenter
+++ b/inventory/2-datacenter
@@ -46,3 +46,7 @@ host-[09:10]
 [proxy_servers]
 host-[04:05]
 host-[09:10]
+
+[vpn_servers]
+host-02
+host-07

--- a/roles/openconnect/README.rst
+++ b/roles/openconnect/README.rst
@@ -1,0 +1,96 @@
+==========================
+OpenConnect SSL VPN server
+==========================
+
+This ansible role deploys `OpenConnect VPN <http://www.infradead.org/ocserv/>`_ server which has (currently experimental) compatibility with clients using the AnyConnect SSL VPN.
+
+************
+Prerequisite
+************
+
+* CentOS 7
+* Installed EPEL repository
+* Installed Iptables service
+
+*********
+Variables
+*********
+
+Common variables
+================
+
+============================  ==================================  ==========================
+Variable                      Description                         Default value
+============================  ==================================  ==========================
+openconnect_conf_path         path to configuration files         /etc/ocserv
+openconnect_passwd_file       path to the password file           /etc/ocserv/ocpasswd
+openconnect_conf_file         path to the default ocserv.conf     /etc/ocserv/ocserv.conf
+openconnect_user              owner user of openconnect service   ocserv
+openconnect_group             owner group of openconnect service  ocserv
+openconnect_tcp_port          TCP port for service                443
+openconnect_udp_port          UDP port for service                443
+openconnect_chroot            chroot for ocserv process           /var/lib/ocserv
+============================  ==================================  ==========================
+
+SSL certificates variables
+==========================
+
+If you don't have any SSL certificates for the VPN server in files directory this role automatically generates CA and server private keys and certificates in .pem format.
+
+============================  ==================================================  ============================
+Variable                      Description                                         Default value
+============================  ==================================================  ============================
+openconnect_cert              name of the server certificate file                 server-cert.pem
+openconnect_key               name of the server key file                         server-key.pem
+openconnect_ca_cert           name of the CA certificate file                     ca-cert.pem
+openconnect_ca_key            name of the CA key file                             ca-key.pem
+openconnect_cert_path         path to the server certificate                      /etc/ocserv/server-cert.pem
+openconnect_key_path          path to the server key                              /etc/ocserv/server-key.pem
+openconnect_ca_cert_path      path to the CA certificate                          /etc/ocserv/ca-cert.pem
+openconnect_ca_key_path       path to the CA key                                  /etc/ocserv/ca-key.pem
+openconnect_ca_template       template for generating ca key and certificate      /etc/ocserv/ca.tmpl
+openconnect_server_template   template for generating server key and certificate  /etc/ocserv/server.tmpl
+openconnect_org               Organization field for certificate generation       "Example Inc."
+============================  ==================================================  ============================
+
+
+Client network variables
+========================
+
+============================  =============================  ============================
+Variable                      Description                    Default value
+============================  =============================  ============================
+openconnect_int_net           tunnel network                 192.168.253.0
+openconnect_int_mask          mask for the tunnel network    255.255.255.0
+openconnect_dns               DNS server for a client        8.8.8.8
+openconnect_route_list        list with injected routes      directly connected network
+============================  =============================  ============================
+
+By default OpenConnect server inject route for directly connected network to the client.
+You can change this behaviour adding routes into the list. For example redefine this variable:
+
+openconnect_route_list: [ "192.168.1.0/255.255.255.0", "172.16.0.0/255.255.0.0" ]
+
+The client will get only routes 192.168.1.0/24 and 172.16.0.0/16
+
+To route all client's traffic through the tunnel just define an empty list: openconnect_route_list: [ ]
+
+
+
+Authentication
+==============
+
+This role uses authentication from file with hashed password. You can specify a list of dictionaries with username and password values.
+
+============================  =======================================  ==================================
+Variable                      Description                              Default value
+============================  =======================================  ==================================
+openconnect_users             List with username and password values   - {username: test, password: pass}
+============================  =======================================  ==================================
+
+********************************************************
+Cisco AnyConnect Secure Mobility Client interoperability
+********************************************************
+
+To start with VPN connection just enter IP address of the VPN server and then click the Connect button.
+If you have self-signed certificates you need to disable option "Block connection to untrusted servers" in the Cisco AnyConnect Secure Mobility Client settings.

--- a/roles/openconnect/defaults/main.yml
+++ b/roles/openconnect/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+
+openconnect_conf_path: /etc/ocserv
+openconnect_passwd_file: "{{ openconnect_conf_path }}/ocpasswd"
+openconnect_conf_file: "{{ openconnect_conf_path }}/ocserv.conf"
+openconnect_user: ocserv
+openconnect_group: ocserv
+openconnect_tcp_port: 443
+openconnect_udp_port: 443
+openconnect_chroot: /var/lib/ocserv
+
+openconnect_cert:  server-cert.pem
+openconnect_key: server-key.pem
+
+openconnect_ca_cert:  ca-cert.pem
+openconnect_ca_key: ca-key.pem
+
+openconnect_cert_path:  "{{ openconnect_conf_path }}/{{ openconnect_cert }}"
+openconnect_key_path: "{{ openconnect_conf_path }}/{{ openconnect_key }}"
+
+openconnect_ca_cert_path:  "{{ openconnect_conf_path }}/{{ openconnect_ca_cert }}"
+openconnect_ca_key_path: "{{ openconnect_conf_path }}/{{ openconnect_ca_key }}"
+
+openconnect_ca_template: "{{ openconnect_conf_path }}/ca.tmpl"
+openconnect_server_template: "{{ openconnect_conf_path }}/server.tmpl"
+openconnect_cert_gen_script: "{{ openconnect_conf_path }}/gen_certs.sh"
+
+openconnect_int_net: 192.168.253.0
+openconnect_int_mask: 255.255.255.0
+openconnect_dns: 8.8.8.8
+
+openconnect_org: "Example Inc."
+
+openconnect_route_list: [ "{{ ansible_default_ipv4.network }}/{{ ansible_default_ipv4.netmask }}" ]
+
+openconnect_users:
+  - {username: test, password: pass}

--- a/roles/openconnect/handlers/main.yml
+++ b/roles/openconnect/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: restart openconnect
+  sudo: yes
+  service:
+    name: ocserv
+    state: restarted
+
+- name: reload openconnect
+  sudo: yes
+  service:
+    name: ocserv
+    state: reloaded

--- a/roles/openconnect/tasks/certificates.yml
+++ b/roles/openconnect/tasks/certificates.yml
@@ -1,0 +1,52 @@
+- name: copy ca certificate template
+  sudo: yes
+  template:
+    src: ca.tmpl.j2
+    dest: "{{ openconnect_ca_template }}"
+    owner: root
+    group: root
+    mode: 0644
+  register: ca_template
+  tags:
+    - openconnect
+
+- name: copy server certificate template
+  sudo: yes
+  template:
+    src: server.tmpl.j2
+    dest: "{{ openconnect_server_template }}"
+    owner: root
+    group: root
+    mode: 0644
+  register: server_template
+  tags:
+    - openconnect
+
+- name: check server key file
+  stat:
+    path: "{{ openconnect_key_path }}"
+  register: key_file
+
+- name: check server cert file
+  stat:
+    path: "{{ openconnect_cert_path }}"
+  register: cert_file
+
+- name: copy certificate generation script
+  sudo: yes
+  template:
+    src: gen_certs.sh.j2
+    dest: "{{ openconnect_cert_gen_script }}"
+    owner: root
+    group: root
+    mode: 0755
+  tags:
+    - openconnect
+
+- name: generate certificates
+  sudo: yes
+  command: "{{ openconnect_cert_gen_script }}"
+  when: server_template.changed or ca_template.changed or not cert_file.stat.exists or not key_file.stat.exists
+  notify: restart openconnect
+  tags:
+    - openconnect

--- a/roles/openconnect/tasks/configure.yml
+++ b/roles/openconnect/tasks/configure.yml
@@ -1,0 +1,66 @@
+- name: check local server key
+  local_action: stat path="{{ role_path }}/files/server-key.pem"
+  register: local_server_key
+
+- name: check local server cert
+  local_action: stat path="i{{ role_path }}/files/server-cert.pem"
+  register: local_server_cert
+
+- name: copy local server key
+  copy:
+    src: "{{ openconnect_key }}"
+    dest: "{{ openconnect_conf_path }}"
+    mode: 0600
+    owner: root
+    group: root
+  ignore_errors: yes
+  register: copy_server_key
+  when: local_server_key.stat.exists
+
+- name: copy local server cert
+  copy:
+    src: "{{ openconnect_cert }}"
+    dest: "{{ openconnect_conf_path }}"
+    mode: 0644
+    owner: root
+    group: root
+  ignore_errors: yes
+  register: copy_server_cert
+  when: local_server_cert.stat.exists
+
+- include: certificates.yml
+  when: not local_server_key.stat.exists or not local_server_cert.stat.exists
+
+- name: generate users and passwords
+  sudo: yes
+  shell: echo -e "{{ item.password }}\n{{ item.password }}" | (ocpasswd -c /etc/ocserv/ocpasswd {{ item.username }})
+  with_items:
+    - "{{ openconnect_users }}"
+  tags:
+    - openconnect
+
+- name: enable openconnect
+  sudo: yes
+  service:
+    name: ocserv
+    enabled: yes
+  tags:
+    - openconnect
+
+- name: copy config files
+  sudo: yes
+  template:
+    src: ocserv.conf.j2
+    dest: "{{ openconnect_conf_file }}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: reload openconnect
+  tags:
+    - openconnect
+
+- name: be sure openconnect service is started
+  sudo: yes
+  service:
+    name: ocserv 
+    state: started

--- a/roles/openconnect/tasks/install.yml
+++ b/roles/openconnect/tasks/install.yml
@@ -1,0 +1,27 @@
+---
+
+- name: check epel repository
+  sudo: yes
+  yum:
+    pkg: epel-release
+    state: present
+  tags:
+    - openconnect
+
+- name: install openconnect
+  sudo: yes
+  yum:
+    pkg: ocserv
+    state: installed
+  tags:
+    - openconnect
+
+- name: copy systemd unit file
+  sudo: yes
+  template:
+    src: ocserv.service.j2
+    dest: /usr/lib/systemd/system/ocserv.service
+    owner: root
+    group: root
+  tags:
+    - openconnect

--- a/roles/openconnect/tasks/main.yml
+++ b/roles/openconnect/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- include: install.yml
+- include: configure.yml
+- include: networking.yml

--- a/roles/openconnect/tasks/networking.yml
+++ b/roles/openconnect/tasks/networking.yml
@@ -1,0 +1,63 @@
+---
+
+- name: enable ipv4 forwarding
+  sudo: yes
+  sysctl:
+    name: "net.ipv4.ip_forward"
+    value: 1
+    state: present
+    reload: yes
+  tags:
+    - opennconect
+
+- name: get iptables rules
+  sudo: yes
+  command: /sbin/iptables -L
+  register: iptables_rules
+  always_run: yes
+  sudo: true
+  tags:
+    - opennconect
+
+- name: get iptables nat rules
+  sudo: yes
+  command: /sbin/iptables -L -t nat
+  register: iptables_nat_rules
+  always_run: yes
+  sudo: true
+  tags:
+    - opennconect
+
+- name: add iptable rule for input tcp connection
+  sudo: yes
+  command: /sbin/iptables -I INPUT -p tcp --dport {{ openconnect_tcp_port }} -j ACCEPT -m comment --comment "VPN TCP input"
+  when: iptables_rules.stdout.find("VPN TCP input") == -1
+  tags:
+    - opennconect
+
+- name: add iptable rule for input udp connection
+  sudo: yes
+  command: /sbin/iptables -I INPUT -p udp --dport {{ openconnect_tcp_port }} -j ACCEPT -m comment --comment "VPN UDP input"
+  when: iptables_rules.stdout.find("VPN UDP input") == -1
+  tags:
+    - opennconect
+
+- name: add iptable rule for forwarding vpn traffic
+  sudo: yes
+  command: /sbin/iptables -A FORWARD -s {{ openconnect_int_net }}/{{ openconnect_int_mask }} -j ACCEPT  -m comment --comment "VPN forwarding"
+  when: iptables_rules.stdout.find("VPN forwarding") == -1
+  tags:
+    - opennconect
+
+- name: add iptable rule for vpn nat
+  sudo: yes
+  command: /sbin/iptables -t nat -I POSTROUTING -s {{ openconnect_int_net }}/{{ openconnect_int_mask }} -o {{ ansible_default_ipv4.interface }} -j MASQUERADE -m comment --comment "VPN NAT"
+  when: iptables_nat_rules.stdout.find("VPN NAT") == -1
+  tags:
+    - opennconect
+
+- name: save iptables
+  sudo: yes
+  command: iptables-save
+  tags:
+    - opennconect

--- a/roles/openconnect/tasks/networking.yml
+++ b/roles/openconnect/tasks/networking.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: enable ipv4 forwarding
   sudo: yes
   sysctl:

--- a/roles/openconnect/templates/ca.tmpl.j2
+++ b/roles/openconnect/templates/ca.tmpl.j2
@@ -1,0 +1,8 @@
+cn = "VPN CA"
+organization = "{{openconnect_org}}"
+serial = 1
+expiration_days = -1
+ca
+signing_key
+cert_signing_key
+crl_signing_key

--- a/roles/openconnect/templates/gen_certs.sh.j2
+++ b/roles/openconnect/templates/gen_certs.sh.j2
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+certtool --generate-privkey --outfile {{ openconnect_ca_key_path}}
+certtool --generate-self-signed --load-privkey {{ openconnect_ca_key_path }} \
+  --template {{ openconnect_conf_path }}/ca.tmpl \
+  --outfile  {{ openconnect_ca_cert_path }}
+certtool --generate-privkey --outfile  {{openconnect_key_path}}
+certtool --generate-certificate --load-privkey {{ openconnect_key_path }} \
+  --load-ca-certificate {{ openconnect_ca_cert_path }} \
+  --load-ca-privkey {{ openconnect_ca_key_path }} \
+  --template {{ openconnect_conf_path }}/server.tmpl \
+  --outfile {{ openconnect_cert_path }}

--- a/roles/openconnect/templates/ocserv.conf.j2
+++ b/roles/openconnect/templates/ocserv.conf.j2
@@ -1,0 +1,40 @@
+auth = "plain[passwd={{ openconnect_passwd_file }}]"
+tcp-port = {{ openconnect_tcp_port }}
+udp-port = {{ openconnect_udp_port }}
+run-as-user = {{ openconnect_user }}
+run-as-group = {{ openconnect_user }}
+socket-file = ocserv.sock
+chroot-dir = {{ openconnect_chroot }}
+isolate-workers = true
+max-clients = 16
+max-same-clients = 16
+keepalive = 32400
+dpd = 90
+mobile-dpd = 1800
+try-mtu-discovery = false
+server-cert = {{ openconnect_cert_path }}
+server-key = {{ openconnect_key_path }}
+tls-priorities = "NORMAL:%SERVER_PRECEDENCE:%COMPAT:-VERS-SSL3.0"
+auth-timeout = 40
+cookie-timeout = 300
+rekey-time = 172800
+rekey-method = ssl
+use-utmp = true
+use-occtl = true
+pid-file = /var/run/ocserv.pid
+device = vpns
+predictable-ips = true
+ipv4-network = {{ openconnect_int_net }}
+ipv4-netmask = {{ openconnect_int_mask }}
+dns = {{ openconnect_dns }}
+ping-leases = false
+{% if openconnect_route_list is defined and openconnect_route_list %}
+{% for custom_route in openconnect_route_list %}
+route = {{ custom_route }}
+{% endfor %}
+{% endif %}
+select-group = connect
+auto-select-group = true
+route-add-cmd = "ip route add %{R} dev %{D}"
+route-del-cmd = "ip route delete %{R} dev %{D}"
+cisco-client-compat = true

--- a/roles/openconnect/templates/ocserv.service.j2
+++ b/roles/openconnect/templates/ocserv.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=OpenConnect SSL VPN server
+Documentation=man:ocserv(8)
+After=network-online.target
+After=dbus.service
+
+[Service]
+PrivateTmp=true
+PIDFile=/var/run/ocserv.pid
+ExecStart=/usr/sbin/ocserv --foreground --pid-file /var/run/ocserv.pid --config {{ openconnect_conf_file }}
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/openconnect/templates/server.tmpl.j2
+++ b/roles/openconnect/templates/server.tmpl.j2
@@ -1,0 +1,7 @@
+cn = {{ ansible_default_ipv4.address }}
+organization = "{{ openconnect_org }}"
+serial = 2
+expiration_days = 999
+signing_key
+encryption_key
+tls_www_server

--- a/vpn-server.yml
+++ b/vpn-server.yml
@@ -1,0 +1,4 @@
+---
+- hosts: vpn_servers
+  roles:
+    - openconnect


### PR DESCRIPTION
This playbook installs OpenConnect VPN SSL server role.

To run playbook just execute ansible-playbook -i inventory/1-datacenter vpn-server.yml.
The role will be installed on the host-02 by default. You can change this in inventory files or vpn-server.yml.
Make sure you change default username:password pair in the openconnect_users variable before deploying this role to the server.

The detailed info about the role is in the README file.