### PR TITLE
Bug in ansible collectd role

### DIFF
--- a/roles/collectd/tasks/main.yml
+++ b/roles/collectd/tasks/main.yml
@@ -25,7 +25,7 @@
     state: directory
     mode: 0755
   tags:
-  - collectd
+    - collectd
 
 - name: create collectd plugin directory
   sudo: yes

--- a/roles/collectd/tasks/main.yml
+++ b/roles/collectd/tasks/main.yml
@@ -18,6 +18,15 @@
   tags:
     - collectd
 
+- name: create collectd config directory
+  sudo: yes
+  file:
+    path: /etc/collectd.d
+    state: directory
+    mode: 0755
+  tags:
+  - collectd
+
 - name: create collectd plugin directory
   sudo: yes
   file:

--- a/roles/docker/tasks/collectd.yml
+++ b/roles/docker/tasks/collectd.yml
@@ -11,6 +11,16 @@
     - docker
     - collectd
 
+- name: create collectd config directory
+  sudo: yes
+  file:
+    path: /etc/collectd.d
+    state: directory
+    mode: 0755
+  tags:
+    - docker
+    - collectd
+
 - name: create collectd plugin directory
   sudo: yes
   file:

--- a/roles/docker/tasks/collectd.yml
+++ b/roles/docker/tasks/collectd.yml
@@ -11,6 +11,16 @@
     - docker
     - collectd
 
+- name: create collectd plugin directory
+  sudo: yes
+  file:
+    path: /usr/share/collectd/plugins
+    state: directory
+    mode: 0755
+  tags:
+    - docker
+    - collectd
+
 - name: install collectd docker plugin
   sudo: yes
   copy:

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -34,6 +34,7 @@
     - common
     - logrotate
     - consul-template
+    - collectd
     - docker
     - nginx
     - consul


### PR DESCRIPTION
Bug in ansible collectd role which affects master branch deployment.

Ansible output:
```
TASK: [docker | install collectd docker plugin] ***************************** 
failed: [qa3-worker-02] => (item=dockerplugin.py) => {"checksum": "a643733cc27e880197f40925ba045aac59d11788", "failed": true, "item": "dockerplugin.py"}
msg: Destination directory /usr/share/collectd/plugins does not exist

TASK: [docker | configure collectd docker plugin] *************************
failed: [qa3-control-03] => {"checksum": "7d8913212991dd5b5a7ac2dd7ffa96a8b06a19d7", "failed": true}
failed: [qa3-worker-02] => {"checksum": "7d8913212991dd5b5a7ac2dd7ffa96a8b06a19d7", "failed": true}
msg: Destination directory /etc/collectd.d does not exist
msg: Destination directory /etc/collectd.d does not exist
```