### PR TITLE
Fixed error for OpenStack Terraform module

### DIFF
--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -4,6 +4,7 @@ variable tenant_name { }
 variable region { }
 variable control_flavor_name { }
 variable resource_flavor_name { }
+variable flavor_name { }
 variable net_id { }
 variable keypair_name { }
 variable image_name { }

--- a/terraform/openstack/keypair/main.tf
+++ b/terraform/openstack/keypair/main.tf
@@ -20,3 +20,7 @@ resource "openstack_compute_keypair_v2" "keypair" {
 output "keypair_name" {
 	value = "${ openstack_compute_keypair_v2.keypair.name }"
 }
+
+output "region" {
+	value = "${ openstack_compute_keypair_v2.keypair.region }"
+}


### PR DESCRIPTION
While trying to make **terraform plan** or **apply** we're geting this error:
Errors:
  * 1 error(s) occurred:
* module.dc2-hosts: missing dependency: module.dc2-keypair.output.region

The reason is missing output for **region** in **openstack/keypair/main.tf**.

