### PR TITLE
Feature/logging consul syslog

### DIFF
--- a/roles/collectd/tasks/main.yml
+++ b/roles/collectd/tasks/main.yml
@@ -18,6 +18,15 @@
   tags:
     - collectd
 
+- name: enable collectd
+  sudo: yes
+  service:
+    name: collectd
+    enabled: yes
+    state: started
+  tags:
+    - collectd
+
 - name: create collectd plugin directory
   sudo: yes
   file:

--- a/roles/consul-template/files/consul.cfg
+++ b/roles/consul-template/files/consul.cfg
@@ -1,2 +1,6 @@
 consul = "127.0.0.1:8500"
 log_level = "debug"
+
+syslog {
+  enabled = true
+}

--- a/roles/consul/templates/consul.json.j2
+++ b/roles/consul/templates/consul.json.j2
@@ -21,5 +21,6 @@
   "verify_outgoing": true,
   "data_dir": "/var/lib/consul",
   "ui_dir": "/usr/share/consul-ui",
+  "enable_syslog": true,
   "disable_remote_exec": {{ consul_disable_remote_exec|to_nice_json }}
 }


### PR DESCRIPTION
* enables syslog logging for consul and consul-template so that the logs are more easily picked up by logstash
* fixes a problem where collectd was not configured to start at boot time

