### PR TITLE
Add Chronos role

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/vagrant", type: "rsync"
 
   config.vm.network :forwarded_port, guest: 2181,  host: 2181  # ZooKeeper
+  config.vm.network :forwarded_port, guest: 4400,  host: 4400  # Chronos
   config.vm.network :forwarded_port, guest: 5050,  host: 5050  # Mesos leader
   config.vm.network :forwarded_port, guest: 15050, host: 15050 # Mesos leader UI
   config.vm.network :forwarded_port, guest: 5051,  host: 5051  # Mesos follower

--- a/roles/chronos/README.rst
+++ b/roles/chronos/README.rst
@@ -1,0 +1,51 @@
+Chronos
+=======
+
+.. versionadded:: 0.1
+
+`Chronos <http://http://mesos.github.io/chronos/>`_ It is a distributed 
+and fault-tolerant scheduler that runs on top of Apache Mesos that can 
+be used for job orchestration. It supports custom Mesos executors as well 
+as the default command executor. 
+Thus by default, Chronos executes sh (on most systems bash) scripts.
+
+Chronos listens on port 4400.
+
+Variables
+---------
+
+.. data:: chronos_zk_auth
+
+   Zookeeper authentication user and digest (right now disabled due to bug in chronos)
+
+.. data:: chronos_zk_dns
+
+   DNS name of the Zookeeper service to connect to
+
+.. data:: chronos_zk_port
+
+   Port of the Zookeeper service to connect to
+
+.. data:: chronos_zk_chroot
+
+   Root path of the chronos service in the Zookeeper
+
+.. data:: chronos_zk_connect
+
+   Connecton string for the Zookeeper service
+
+.. data:: chronos_zk_mesos_master
+
+   URL of the mesos master leader service in Zookeeper
+
+.. data:: zk_docker_image
+
+   Zookeeper docker container image name
+
+.. data:: chronos_port
+
+   Chronos service port
+
+.. data:: chronos_proxy_port
+
+   Chronos proxy port

--- a/roles/chronos/defaults/main.yml
+++ b/roles/chronos/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# right now there is an issue with chronos zookeeper connection with auth, so leave it blank for now
+chronos_zk_auth: "" 
+chronos_zk_dns: "zookeeper.service.{{ consul_dns_domain }}"
+chronos_zk_port: 2181
+chronos_zk_chroot: chronos
+chronos_zk_connect: "zk://{{chronos_zk_auth}}{{ chronos_zk_dns }}:{{ chronos_zk_port }}/{{chronos_zk_chroot}}"
+
+chronos_zk_mesos_master: "zk://{{ chronos_zk_dns }}:{{ chronos_zk_port }}/mesos"
+
+# zookeeper
+zk_docker_image: "ciscocloud/zookeeper:0.2"
+chronos_zk_acl_world: "world:anyone:cdrwa"
+chronos_zk_acl: "{% if zk_chronos_user_secret is defined %}digest:{{ zk_chronos_user }}:{{ zk_chronos_user_secret_digest}}:cdraw{% endif  %}"
+
+chronos_zk_acl_cmd: "docker run --rm -e ZK_AUTH=super:{{ zk_super_user_secret }} -e ZNODE=/{{ chronos_zk_chroot }} -e ZNODE_ACL={{ chronos_zk_acl_world }},{{ chronos_zk_acl }} -e ZK_SERVER={{ chronos_zk_dns }}:{{ chronos_zk_port }} --entrypoint /usr/local/bin/setacl.sh {{ zk_docker_image }}"
+
+chronos_port: 14400
+chronos_proxy_port: 4400
+
+# framework authentication
+
+# register service with consul
+consul_bin: /bin/consul
+consul_dir: /etc/consul
+consul_nginx_image: ciscocloud/nginx-consul
+consul_nginx_image_tag: 1.1

--- a/roles/chronos/files/chronos-consul.cfg
+++ b/roles/chronos/files/chronos-consul.cfg
@@ -1,0 +1,5 @@
+template {
+	source = "/etc/consul-template/templates/chronos-iptables.tmpl"
+	destination = "/tmp/chronos-iptables.sh"
+	command = "/bin/bash /tmp/chronos-iptables.sh"
+}

--- a/roles/chronos/handlers/main.yml
+++ b/roles/chronos/handlers/main.yml
@@ -1,0 +1,20 @@
+---
+- name: reload chronos
+  sudo: yes
+  command: systemctl daemon-reload
+
+- name: restart chronos
+  sudo: yes
+  command: systemctl restart chronos
+
+- name: reload consul
+  sudo: yes
+  command: "{{ consul_bin }} reload"
+
+- name: restart nginx-chronos
+  sudo: yes
+  command: systemctl restart nginx-chronos
+
+- name: reload nginx-chronos
+  sudo: yes
+  command: systemctl daemon-reload

--- a/roles/chronos/meta/main.yml
+++ b/roles/chronos/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: handlers

--- a/roles/chronos/tasks/framework_auth.yml
+++ b/roles/chronos/tasks/framework_auth.yml
@@ -1,0 +1,51 @@
+---
+- name: create secret file
+  sudo: yes
+  when: do_mesos_framework_auth|bool
+  copy:
+    dest: /etc/chronos/mesos_authentication_secret
+    content: "{{ chronos_secret }}"
+  notify:
+    - restart chronos
+  tags:
+    - chronos
+
+- name: set principal and secret
+  sudo: yes
+  when: do_mesos_framework_auth|bool
+  copy:
+    dest: /etc/chronos/conf/{{ item.key }}
+    content: "{{ item.value }}"
+  with_items:
+    - key: mesos_authentication_principal
+      value: "{{ chronos_principal }}"
+    - key: mesos_authentication_secret_file
+      value: /etc/chronos/mesos_authentication_secret
+  notify:
+    - restart chronos
+  tags:
+    - chronos
+
+# remove if option become unset
+- name: remove secret file
+  sudo: yes
+  when: not do_mesos_framework_auth|bool
+  file:
+    dest: /etc/chronos/mesos_authentication_secret
+    state: absent
+  notify:
+    - restart chronos
+
+- name: remove principal and secret
+  sudo: yes
+  when: not do_mesos_framework_auth|bool
+  file:
+    dest: /etc/chronos/conf/{{ item }}
+    state: absent
+  with_items:
+    - mesos_authentication_principal
+    - mesos_authentication_secret_file
+  notify:
+    - restart chronos
+  tags:
+    - chronos

--- a/roles/chronos/tasks/main.yml
+++ b/roles/chronos/tasks/main.yml
@@ -1,0 +1,134 @@
+---
+- name: add mesosphere repository
+  sudo: yes
+  yum:
+    name:  http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm 
+    state: present
+  tags:
+    - chronos
+
+- name: install chronos package
+  sudo: yes
+  yum:
+    name: chronos
+    state: present
+  tags:
+    - chronos
+
+- name: create zookeeper acl
+  sudo: yes
+  command: "{{ chronos_zk_acl_cmd }}"
+  notify:
+    - restart chronos
+  when: zk_chronos_user_secret is defined
+  run_once: true
+  tags:
+    - chronos
+
+- name: create chronos conf directory
+  sudo: yes
+  file:
+    dest: /etc/chronos/conf
+    state: directory
+  tags:
+    - chronos
+
+- include: framework_auth.yml
+
+- name: configure chronos unit file
+  sudo: yes
+  replace:
+    dest: /usr/lib/systemd/system/chronos.service
+    regexp: "=network.target"
+    replace: '=mesos-master.service'
+  notify:
+    - reload chronos
+    - restart chronos
+  tags:
+    - chronos
+
+- name: fix chronos bin file
+  sudo: yes
+  replace:
+    dest: /usr/bin/chronos
+    regexp: '\[\[ -s /etc/mesos/zk \]\]'
+    replace: 'false'
+  notify:
+    - restart chronos
+  tags:
+    - chronos
+
+- name: set key/value options
+  sudo: yes
+  when: item.value != ""
+  copy:
+    dest: /etc/chronos/conf/{{ item.key }}
+    content: "{{ item.value }}"
+  with_items:
+    - key: zk_hosts
+      value: "{{ chronos_zk_connect }}"
+    - key: master
+      value: "{{ chronos_zk_mesos_master }}"
+    - key: http_port
+      value: "{{ chronos_port }}"
+    - key: mesos_framework_name
+      value: "chronos"
+  notify:
+    - restart chronos
+  tags:
+    - chronos
+
+- name: enable and start chronos
+  sudo: yes
+  service:
+    enabled: yes
+    name: chronos
+    state: started
+  tags:
+    - chronos
+
+- meta: flush_handlers
+
+- include: nginx-proxy.yml
+
+- name: deploy iptables configuration
+  sudo: yes
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - src: chronos-consul.cfg
+      dest: /etc/consul-template/config.d
+  notify:
+    - reload consul-template
+  tags:
+    - chronos
+
+- name: deploy iptables template
+  sudo: yes
+  template:
+    src: chronos-iptables.tmpl.j2
+    dest: /etc/consul-template/templates/chronos-iptables.tmpl
+  notify:
+    - reload consul-template
+  tags:
+    - chronos
+
+- name: ensure consul.d is present
+  sudo: yes
+  file:
+    path: "{{ consul_dir }}"
+    state: directory
+  tags:
+    - chronos
+
+- name: generate chronos consul service
+  sudo: yes
+  template:
+    src: chronos-consul.j2
+    dest: "{{ consul_dir }}/chronos.json"
+  notify:
+    - reload consul
+  tags:
+    - chronos
+

--- a/roles/chronos/tasks/nginx-proxy.yml
+++ b/roles/chronos/tasks/nginx-proxy.yml
@@ -1,0 +1,43 @@
+---
+- name: copy nginx configuration
+  sudo: yes
+  template:
+    src: chronos.nginx.j2
+    dest: /etc/chronos/chronos.nginx
+  notify:
+    - restart nginx-chronos
+  tags:
+    - chronos
+
+- name: configure nginx
+  sudo: yes
+  command: curl -X PUT -d @/etc/chronos/chronos.nginx localhost:8500/v1/kv/service/nginx/templates/chronos
+  tags:
+    - chronos
+
+- name: configure nginx-chronos
+  sudo: yes
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - src: nginx-chronos.service.j2
+      dest: /usr/lib/systemd/system/nginx-chronos.service
+    - src: nginx-chronos.env.j2
+      dest: /etc/default/nginx-chronos.env
+  notify:
+    - reload nginx-chronos
+    - restart nginx-chronos
+  tags:
+    - chronos
+
+- name: enable nginx-chronos
+  sudo: yes
+  service:
+    name: nginx-chronos
+    enabled: yes
+    state: started
+  notify:
+    - restart nginx-chronos
+  tags:
+    - chronos

--- a/roles/chronos/templates/chronos-consul.j2
+++ b/roles/chronos/templates/chronos-consul.j2
@@ -1,0 +1,11 @@
+{ 
+  "service": {
+    "name": "chronos",
+    "tags": [ "chronos" ],
+    "port": 14400,
+    "check": {
+      "script": "curl --silent --show-error --fail --dump-header /dev/stderr --retry 2 http://127.0.0.1:14400/ping",
+      "interval": "10s"
+    }
+  }
+}

--- a/roles/chronos/templates/chronos-iptables.tmpl.j2
+++ b/roles/chronos/templates/chronos-iptables.tmpl.j2
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+iptables -F CHRONOS
+iptables -D INPUT -p tcp --dport {{ chronos_port }} -j CHRONOS
+iptables -X CHRONOS
+
+iptables -N CHRONOS
+
+{% if not do_chronos_iptables|bool %}exit 0
+{% endif %}
+
+{% raw %}{{ range service "chronos" "any" }}{% endraw %}
+iptables -A CHRONOS -p tcp --dport {{ chronos_port }} -s {% raw %}{{ .Address }}{% endraw %} -j ACCEPT
+{% raw %}{{ end }}{% endraw %}
+iptables -A CHRONOS -p tcp --dport {{ chronos_port }} -d 127.0.0.1 -j ACCEPT
+iptables -A CHRONOS -p tcp --dport {{ chronos_port }} -i docker0 -j ACCEPT
+iptables -A CHRONOS -p tcp --dport {{ chronos_port }} -j DROP
+
+iptables -A INPUT -p tcp --dport {{ chronos_port }} -j CHRONOS

--- a/roles/chronos/templates/chronos.nginx.j2
+++ b/roles/chronos/templates/chronos.nginx.j2
@@ -1,0 +1,44 @@
+worker_processes	1;
+
+events {
+	worker_connections	1024;
+}
+
+http {
+	include		mime.types;
+	default_type	application/octet-stream;
+
+	sendfile		on;
+	keepalive_timeout	65;
+
+	server {
+		listen {{ chronos_proxy_port }} {% if do_chronos_ssl|bool %}ssl{% endif %};
+
+{% if do_chronos_ssl|bool -%}
+		ssl_certificate		/etc/nginx/ssl/nginx.cert;
+		ssl_certificate_key	/etc/nginx/ssl/nginx.key;
+
+		ssl on;
+		ssl_session_cache	builtin:1000 shared:SSL:10m;
+		ssl_protocols		TLSv1 TLSv1.1 TLSv1.2;
+		ssl_ciphers		HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
+		ssl_prefer_server_ciphers	on;
+
+		error_page 497 https://$host:$server_port$request_uri;
+{% endif %}
+
+		location / {
+			proxy_connect_timeout	600;
+			proxy_send_timeout	600;
+			proxy_read_timeout	600;
+			send_timeout		600;
+
+{% if do_chronos_auth|bool %}
+			auth_basic on;
+			auth_basic_user_file /etc/nginx/nginx-auth.conf;
+{% endif %}
+
+			proxy_pass http://{% raw %}{{ env "NGINX_PUBLIC_IP" }}{% endraw %}:{{ chronos_port }}/;
+		}
+	}
+}

--- a/roles/chronos/templates/nginx-chronos.env.j2
+++ b/roles/chronos/templates/nginx-chronos.env.j2
@@ -1,0 +1,8 @@
+NGINX_KV=service/nginx/templates/chronos
+NGINX_AUTH_TYPE=basic
+NGINX_AUTH_BASIC_KV=service/nginx/auth/users
+NGINX_PUBLIC_IP={{ ansible_default_ipv4.address }}
+CONSUL_CONNECT=consul.service.consul:8500
+{% if do_consul_ssl|bool %}
+CONSUL_SSL=true
+{% endif %}

--- a/roles/chronos/templates/nginx-chronos.service.j2
+++ b/roles/chronos/templates/nginx-chronos.service.j2
@@ -1,0 +1,28 @@
+[Unit]
+Description=nginx-marathon
+After=docker.service
+After=consul.service
+Requires=docker.service
+Requires=consul.service
+
+[Service]
+Restart=on-failure
+RestartSec=20
+TimeoutStartSec=0
+
+ExecStartPre=-/usr/bin/docker rm nginx-chronos
+ExecStartPre=-/usr/bin/docker pull {{ consul_nginx_image }}:{{ consul_nginx_image_tag }}
+
+ExecStart=/usr/bin/docker run \
+    --rm \
+    --name=nginx-chronos \
+    -v /etc/nginx/ssl:/etc/nginx/ssl:ro \
+    -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/:ro \
+    --env-file=/etc/default/nginx-chronos.env \
+    -p 4400:4400 \
+    {{ consul_nginx_image }}:{{ consul_nginx_image_tag }}
+
+ExecStop=/usr/bin/docker kill nginx-chronos
+
+[Install]
+WantedBy=multi-user.target

--- a/security-setup
+++ b/security-setup
@@ -104,6 +104,10 @@ broad_opts.add_argument(
     help='Enable Marathon security. This overrides all other Marathon options.'
 )
 broad_opts.add_argument(
+    '--chronos', type=ImplicitBool.parse_opt, default=True,
+    help='Enable Chronos security. This overrides all other Chronos options.'
+)
+broad_opts.add_argument(
     '--iptables', type=ImplicitBool.parse_opt, default=True,
     help='Use iptables rules. This overrides all other options related to iptables.'
 )
@@ -222,6 +226,27 @@ marathon_opts.add_argument(
     '--marathon-iptables', type=ImplicitBool.parse_opt,
     help='enable Marathon iptables rules',
     dest='do_marathon_iptables', default=True
+)
+
+# Chronos security
+chronos_opts = parser.add_argument_group(
+    "Chronos Options",
+    "enable and disable auth components of Chronos"
+)
+chronos_opts.add_argument(
+    '--chronos-ssl', type=ImplicitBool.parse_opt,
+    help='enable Chronos SSL',
+    dest='do_chronos_ssl', default=True
+)
+chronos_opts.add_argument(
+    '--chronos-auth', type=ImplicitBool.parse_opt,
+    help='enable Chronos authentication',
+    dest='do_chronos_auth', default=True
+)
+chronos_opts.add_argument(
+    '--chronos-iptables', type=ImplicitBool.parse_opt,
+    help='enable Chronos iptables rules',
+    dest='do_chronos_iptables', default=True
 )
 
 BASE = posixpath.abspath(posixpath.dirname(__file__)).replace("\\","/")
@@ -580,11 +605,47 @@ class Marathon(Component):
             else:
                 print('marathon http credentials already set')
 
+class Chronos(Component):
+    def check(self):
+        return [self.disable_security, self.mesos_auth, self.password]
+
+    def disable_security(self):
+        "disable security"
+        self.toggle_boolean('do_chronos_auth', self.component_enabled(self.args.do_chronos_auth), True)
+        self.toggle_boolean('do_chronos_ssl', self.component_enabled(self.args.do_chronos_ssl), True)
+        self.toggle_boolean(
+            'do_chronos_iptables',
+            self.component_enabled(self.args.do_chronos_iptables and self.args.iptables),
+            True
+        )
+
+    def mesos_auth(self):
+        "chronos framework authentication"
+        with self.modify_security() as config:
+            config.setdefault('chronos_principal', 'chronos')
+            if 'chronos_secret' not in config:
+                config['chronos_secret'] = self.random()
+                print('set chronos framework secret')
+            else:
+                print('chronos secret already set')
+
+    def password(self):
+        "admin password"
+        with self.modify_security() as config:
+            if 'chronos_http_credentials' not in config or self.args.change_admin_password:
+                config['chronos_http_credentials'] = 'admin:{}'.format(self.ask_pass(
+                    prompt='Admin Password: ',
+                    purpose='admin',
+                ))
+                print('set chronos http credentials')
+            else:
+                print('chronos http credentials already set')
+
 
 class Zookeeper(Component):
     def check(self):
          return [
-             self.super_auth, self.mesos_auth, self.marathon_auth,
+             self.super_auth, self.mesos_auth, self.marathon_auth, self.chronos_auth,
          ]
 
     def super_auth(self):
@@ -625,6 +686,20 @@ class Zookeeper(Component):
             else:
                 print('zk marathon user secret already set')
 
+    def chronos_auth(self):
+        "chronos user auth"
+        with self.modify_security() as config:
+            config.setdefault('zk_chronos_user', 'chronos')
+            if 'zk_chronos_user_secret' not in config:
+                credential = self.randpass()
+                config['zk_chronos_user_secret'] = credential
+                config['zk_chronos_user_secret_digest'] = self.zk_digest(
+                    user='chronos', credential=credential
+                )
+                print('set zk chronos user secret')
+            else:
+                print('zk chronos user secret already set')
+
 
 class Mesos(Component):  # Mesos should always come after any frameworks
     def check(self):
@@ -654,6 +729,15 @@ class Mesos(Component):  # Mesos should always come after any frameworks
                 if credential not in config['mesos_credentials']:
                     config['mesos_credentials'].append(credential)
                     print('set auth for Marathon')
+            if 'chronos_principal' in config and 'chronos_secret' in config:
+#                config.setdefault('mesos_credentials', [])
+                credential = {
+                    'principal': config['chronos_principal'],
+                    'secret': config['chronos_secret'],
+                }
+                if credential not in config['mesos_credentials']:
+                    config['mesos_credentials'].append(credential)
+                    print('set auth for Chronos')
 
     def follower_auth(self):
         "follower auth"

--- a/security-setup
+++ b/security-setup
@@ -605,6 +605,7 @@ class Marathon(Component):
             else:
                 print('marathon http credentials already set')
 
+
 class Chronos(Component):
     def check(self):
         return [self.disable_security, self.mesos_auth, self.password]

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -78,3 +78,4 @@
     - zookeeper
     - mesos
     - marathon
+    - chronos

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -126,6 +126,13 @@ resource "aws_security_group" "control" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress { # Chronos
+    from_port = 4400
+    to_port = 4400
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   ingress { # Consul
     from_port = 8500
     to_port = 8500

--- a/terraform/gce/gce.tf
+++ b/terraform/gce/gce.tf
@@ -32,6 +32,7 @@ resource "google_compute_firewall" "mi-firewall-external" {
     ports = [
       "22",   # SSH
       "3389", # RDP
+      "4400", # Chronos
       "5050", # Mesos
       "8080", # Marathon
       "8500"  # Consul UI

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -22,3 +22,4 @@
     - zookeeper
     - mesos
     - marathon
+    - chronos


### PR DESCRIPTION
Chronos
=======

[Chronos](http://mesos.github.io/chronos) It is a distributed and fault-tolerant scheduler that runs on top of Apache Mesos that can be used for job orchestration. It supports custom Mesos executors as well as the default command executor. 
Thus by default, Chronos executes sh (on most systems bash) scripts.

Chronos listens on port 4400.