### PR TITLE
Fix: kafka not able to write to log folder

### DIFF
--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -33,4 +33,14 @@
   tags:
     - kafka
 
+- name: Create Kafka log directory
+  sudo: true
+  file: 
+    path: "{{ kafka_install_dir }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}/logs"
+    owner: "{{ ansible_user_id }}"
+    mode: 0775
+    state: directory
+  tags:
+    - kafka
+
 - include: config.yml


### PR DESCRIPTION
Error: cannot create directory ‘/usr/local/share/kafka/kafka_2.10-
0.8.2.1/bin/../logs’: Permission denied

Create logs directory with mode 0775

IssueID: Internal