### PR TITLE
Remove redundant code.

### DIFF
--- a/roles/collectd/tasks/main.yml
+++ b/roles/collectd/tasks/main.yml
@@ -8,6 +8,15 @@
     - collectd
     - bootstrap
 
+- name: create collectd plugin directory
+  sudo: yes
+  file:
+    path: /usr/share/collectd/plugins
+    state: directory
+    mode: 0755
+  tags:
+  - collectd
+
 - name: configure collectd
   sudo: yes
   template:
@@ -17,24 +26,6 @@
     - restart collectd
   tags:
     - collectd
-
-- name: create collectd config directory
-  sudo: yes
-  file:
-    path: /etc/collectd.d
-    state: directory
-    mode: 0755
-  tags:
-    - collectd
-
-- name: create collectd plugin directory
-  sudo: yes
-  file:
-    path: /usr/share/collectd/plugins
-    state: directory
-    mode: 0755
-  tags:
-  - collectd
 
 - name: enable collectd
   sudo: yes


### PR DESCRIPTION
Removes redundant directory creation code (/etc/collectd.d is create by collectd package install [as shown on fresh CentOS install](https://gist.github.com/corebug/91af0205f34655ce3ecf)).