### PR TITLE
use consul dns for mesos and marathon

### DIFF
--- a/roles/marathon/tasks/conf.yml
+++ b/roles/marathon/tasks/conf.yml
@@ -34,6 +34,8 @@
       value: 18080
     - key: event_subscriber
       value: http_callback
+    - key: hostname
+      value: "{{ inventory_hostname }}.node.{{ consul_dns_domain }}"
   notify:
     - restart marathon
   tags:

--- a/roles/mesos/tasks/main.yml
+++ b/roles/mesos/tasks/main.yml
@@ -34,6 +34,15 @@
   tags: 
     - mesos
 
+- name: configure /etc/mesos/hostname
+  sudo: yes
+  template:
+    src: hostname.j2
+    dest: /etc/mesos/hostname
+    mode: 0600
+  tags:
+    - mesos
+
 - name: disable mesos leader
   sudo: yes
   service:

--- a/roles/mesos/templates/hostname.j2
+++ b/roles/mesos/templates/hostname.j2
@@ -1,0 +1,1 @@
+{{ inventory_hostname }}.node.{{ consul_dns_domain }}


### PR DESCRIPTION
Please review. This seems to really improve the reliability of provisioning a cluster on AWS and helps with https://github.com/CiscoCloud/microservices-infrastructure/issues/363. Thanks @ChrisAubuchon 