### PR TITLE
OpenStack: Use default security group

### DIFF
--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -9,7 +9,7 @@ variable keypair_name { }
 variable image_name { }
 variable control_count {}
 variable resource_count {}
-variable security_groups {}
+variable security_groups { default = "default" }
 variable short_name { default = "mi" }
 variable long_name { default = "microservices-infrastructure" }
 


### PR DESCRIPTION
The cloud provider's default secgroup is a reasonable default,
as it will allow traffic between other vms also on the default
secgroup.