### PR TITLE
support for Terraform in Dockerfile

### DIFF
--- a/docker_launch.sh
+++ b/docker_launch.sh
@@ -5,20 +5,7 @@ if [ ! -f ./security.yml ]; then
     ./security-setup --enable=false
 fi
 
-cat > wait-for-hosts.yml << EOF
-- hosts: all
-  gather_facts: no
-  tasks:
-
-    - name: wait for ssh to become available
-      local_action: wait_for
-                    port=22
-                    host="{{ ansible_ssh_host | default(inventory_hostname) }}"
-                    search_regex=OpenSSH
-                    delay=10
-EOF
-
 terraform get
 terraform apply -state=$TERRAFORM_STATE_ROOT/terraform.tfstate
-ansible-playbook wait-for-hosts.yml
-ansible-playbook terraform.yml --extra-vars=@security.yml
+ansible-playbook /mi/playbooks/wait-for-hosts.yml
+ansible-playbook /mi/terraform.yml --extra-vars=@security.yml

--- a/docker_launch.sh
+++ b/docker_launch.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+if [ ! -f ./security.yml ]; then
+    ./security-setup --enable=false
+fi
+
+cat > wait-for-hosts.yml << EOF
+- hosts: all
+  gather_facts: no
+  tasks:
+
+    - name: wait for ssh to become available
+      local_action: wait_for
+                    port=22
+                    host="{{ ansible_ssh_host | default(inventory_hostname) }}"
+                    search_regex=OpenSSH
+                    delay=10
+EOF
+
+terraform get
+terraform apply -state=$TERRAFORM_STATE_ROOT/terraform.tfstate
+ansible-playbook wait-for-hosts.yml
+ansible-playbook terraform.yml --extra-vars=@security.yml

--- a/docs/getting_started/dockerfile.rst
+++ b/docs/getting_started/dockerfile.rst
@@ -20,9 +20,9 @@ Setup
    .. toctree::
       :maxdepth: 1
 
-      * openstack.rst
-      * gce.rst
-      * aws.rst
+      openstack.rst
+      gce.rst
+      aws.rst
 
 3. Finally, you need to create a custom ansible playbook for your cluster. You
    can copy `terraform.sample.yml` to `terraform.yml` in your root directory to

--- a/docs/getting_started/dockerfile.rst
+++ b/docs/getting_started/dockerfile.rst
@@ -1,0 +1,77 @@
+Using the Dockerfile
+===========================
+
+.. versionadded:: 0.3.1
+
+.. note:: Please review the :doc:`getting started guide <./index>` for more
+          detailed information about setting up a cluster.
+
+Setup
+--------
+
+1. Before you begin, it is recommended that you run the :doc:`security-setup
+   script <../security/security_setup>` to configure authentication and
+   authorization for the various components.
+
+2. Next, you will need to setup a Terraform template (``*.tf`` file) in the root
+   directory for the cloud provider of your choices. See the following links for
+   more information:
+
+   .. toctree::
+      :maxdepth: 1
+
+      * openstack.rst
+      * gce.rst
+      * aws.rst
+
+3. Finally, you need to create a custom ansible playbook for your cluster. You
+   can copy `terraform.sample.yml` to `terraform.yml` in your root directory to
+   get started.
+
+Building a Docker Image
+-------------------------
+
+Now you'll be able to build a docker image from the `Dockerfile`:
+
+``docker build -t mi .``
+
+In this example, we are tagging the image with the name `mi` which we will be
+using later in this guide.
+
+Running a Container
+---------------------
+
+Now we can run a container from our image to provision a new cluster. Before we
+do that, there are a couple of things to understand.
+
+By default, our Terraform templates are configured with the assumption that you
+have an SSH public key called `id_rsa.pub` in the `.ssh` folder of your home
+directory (along with a corresponding private key). Terraform uses this to
+authorize your key on the cluster nodes that it creates. This provides you with
+SSH access to the nodes which is required for the subsequent Ansible
+provisioning. The simplest way to handle this when running from a Docker
+container is to host mount your `~/.ssh` folder in the container. You will see
+an example of this later in the document.
+
+Another important thing to understand is how Terraform manages `state
+<https://terraform.io/docs/state/index.html>`_. Terraform uses a `JSON`
+formatted file to store the state of your managed infrastructure. This state
+file is important as it will allow you to use Terraform to plan, inspect, modify
+and destroy resources in your infrastructure. By default, Terraform writes state
+to a file called `terraform.tfstate` in the same directory where you launched
+Terraform. Our `Dockerfile` is configured to store the state in a Docker volume
+called `/state`. This will allow you to host mount that volume so that you can
+easily access the `terraform.tfstate` file to use for future Terraform runs.
+
+Now we can use this information to run our container:
+
+``docker run -v ~/.ssh/:/root/.ssh/ -v $PWD:/state mi``
+
+As discussed above, we are launching a container from the `mi` image we created
+earlier and are host mounting our local `~/.ssh/` directory to the container
+user's `.ssh` directory. And we are mounting our current directory to the
+container's `/state` volume. Therefore, the `terraform.tfstate` files will be
+accessible from our local host directory after the run.
+
+The container should launch and provision the cluster using the `security.yml`,
+Terraform template, and custom playbook that you configured in the Setup above.

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -105,4 +105,7 @@ working correctly, use the ``playbooks/reboot-hosts.yml`` playbook.
 
     ansible-playbook playbooks/reboot-hosts.yml
 
+Using a Docker Container to Provision your Cluster
+---------------------------------------------------
 
+You can also provision your cluster by running a docker container. See :doc:`dockerfile` for more information.

--- a/playbooks/wait-for-hosts.yml
+++ b/playbooks/wait-for-hosts.yml
@@ -1,0 +1,9 @@
+- hosts: all
+  gather_facts: no
+  tasks:
+    - name: wait for ssh to become available
+      local_action: wait_for
+                    port=22
+                    host="{{ ansible_ssh_host | default(inventory_hostname) }}"
+                    search_regex=OpenSSH
+                    delay=10

--- a/plugins/inventory/terraform.py
+++ b/plugins/inventory/terraform.py
@@ -373,8 +373,10 @@ def main():
     parser.add_argument('--nometa',
                         action='store_true',
                         help='with --list, exclude hostvars')
-    default_root = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                '..', '..', ))
+    default_root = os.environ.get('TERRAFORM_STATE_ROOT',
+                                  os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                               '..', '..', )))
+
     parser.add_argument('--root',
                         default=default_root,
                         help='custom root to search for `.tfstate`s in')


### PR DESCRIPTION
@stevendborrelli @kenjones-cisco I ended up using a centos base for the
Dockerfile for now. I ran into several issues using alpine. The pre-built
Terraform binaries do not run (I believe due to glibc issues [1]) and building
Terraform from source also was not cooperating (building 0.5.3 appears to broken
[2] due to a relocated dependency repo and there are issues with the AWS
provider on master).

Some potential improvements:

1. Make it easier to manage your cluster with a more sophisticated launch
   script. Right now, the script will automatically provision your cluster. But
   if you want to modify (or destroy) your cluster, you have to just
   launch the container with bash and run the commands manually.

2. If we publish a public container, we should add some documentation about
   using it as a base for a custom image

3. Think about better ways to manage ssh keys and document how you would
   customize the various components (custom image, terraform template, ansible
   config, etc.).

[1] https://github.com/gliderlabs/docker-alpine/issues/11
[2] https://github.com/hashicorp/terraform/pull/2216

fixes #464 