### PR TITLE
OpenStack floating ip support

### DIFF
--- a/docs/getting_started/openstack.rst
+++ b/docs/getting_started/openstack.rst
@@ -24,6 +24,11 @@ the template located at ``terraform/openstack.sample.tf``. It looks like this:
 Copy that file in it's entirety to the root of the project to start
 customization. In the next sections, we'll explain how to obtain these settings.
 
+There is another sample called ``openstack-floating.sample.tf`` in the
+``terraform`` directory. The default sample assumes you are booting VMs directly
+on a public network. Use the floating sample instead if you'd like to provision
+your virtual machines on a private network with floating IPs.
+
 You can also use this file as a base for further customization. For example, you
 can change the names of the modules to be specific to your environment. While we
 will explore the authentication variables in the next sections, you will need to

--- a/plugins/inventory/terraform.py
+++ b/plugins/inventory/terraform.py
@@ -226,6 +226,9 @@ def openstack_host(resource, module_name):
         'provider': 'openstack',
     }
 
+    if 'floating_ip' in raw_attrs:
+        attrs['private_ipv4'] = raw_attrs['network.0.fixed_ip_v4']
+
     try:
         attrs.update({
             'ansible_ssh_host': raw_attrs['access_ip_v4'],

--- a/terraform/openstack-floating.sample.tf
+++ b/terraform/openstack-floating.sample.tf
@@ -1,0 +1,24 @@
+module "dc2-keypair" {
+	source = "./terraform/openstack/keypair"
+	auth_url = ""
+	tenant_id = ""
+	tenant_name = ""
+	public_key = ""
+	keypair_name = ""
+}
+
+module "dc2-hosts-floating" {
+        source = "./terraform/openstack/hosts-floating"
+        auth_url = ""
+        datacenter = "dc2"
+        tenant_id = ""
+        tenant_name = ""
+        control_flavor_name = ""
+        resource_flavor_name  = ""
+        image_name = ""
+        keypair_name = "${ module.dc2-keypair.keypair_name }"
+        control_count = 1
+        resource_count = 2
+	floating_pool = ""
+	external_net_id = ""
+}

--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -1,0 +1,93 @@
+variable auth_url { }
+variable datacenter { default = "openstack" }
+variable tenant_id { }
+variable tenant_name { }
+variable control_flavor_name { }
+variable resource_flavor_name { }
+variable keypair_name { }
+variable image_name { }
+variable control_count {}
+variable resource_count {}
+variable security_groups { default = "default" }
+variable floating_pool {}
+variable external_net_id { }
+variable subnet_cidr { default = "10.10.10.0/24" }
+variable ip_version { default = "4" }
+variable short_name { default = "mi" }
+variable long_name { default = "microservices-infrastructure" }
+variable ssh_user { default = "centos" }
+
+provider "openstack" {
+  auth_url	= "${ var.auth_url }"
+  tenant_id	= "${ var.tenant_id }"
+  tenant_name	= "${ var.tenant_name }"
+}
+
+resource "openstack_compute_instance_v2" "control" {
+  floating_ip = "${ element(openstack_compute_floatingip_v2.ms-control-floatip.*.address, count.index) }"
+  name                  = "${ var.short_name}-control-${format("%02d", count.index+1) }"
+  key_pair              = "${ var.keypair_name }"
+  image_name            = "${ var.image_name }"
+  flavor_name           = "${ var.control_flavor_name }"
+  security_groups       = [ "${ var.security_groups }" ]
+  network               = { uuid = "${ openstack_networking_network_v2.ms-network.id }" }
+  metadata              = {
+                            dc = "${var.datacenter}"
+                            role = "control"
+                            ssh_user = "${ var.ssh_user }"
+                          }
+  count                 = "${ var.control_count }"
+}
+
+resource "openstack_compute_instance_v2" "resource" {
+  floating_ip = "${ element(openstack_compute_floatingip_v2.ms-resource-floatip.*.address, count.index) }"
+  name                  = "${ var.short_name}-worker-${format("%02d", count.index+1) }"
+  key_pair              = "${ var.keypair_name }"
+  image_name            = "${ var.image_name }"
+  flavor_name           = "${ var.resource_flavor_name }"
+  security_groups       = [ "${ var.security_groups }" ]
+  network               = { uuid = "${ openstack_networking_network_v2.ms-network.id }" }
+  metadata              = {
+                            dc = "${var.datacenter}"
+                            role = "worker"
+                            ssh_user = "${ var.ssh_user }"
+                          }
+  count                 = "${ var.resource_count }"
+}
+
+resource "openstack_compute_floatingip_v2" "ms-control-floatip" {
+  pool 	     = "${ var.floating_pool }"
+  count      = "${ var.control_count }"
+  depends_on = [ "openstack_networking_router_v2.ms-router",
+                 "openstack_networking_network_v2.ms-network",
+                 "openstack_networking_router_interface_v2.ms-router-interface" ]
+}
+
+resource "openstack_compute_floatingip_v2" "ms-resource-floatip" {
+  pool       = "${ var.floating_pool }"
+  count      = "${ var.resource_count }"
+  depends_on = [ "openstack_networking_router_v2.ms-router",
+                 "openstack_networking_network_v2.ms-network",
+                 "openstack_networking_router_interface_v2.ms-router-interface" ]
+}
+
+resource "openstack_networking_network_v2" "ms-network" {
+  name = "${ var.short_name }-network"
+}
+
+resource "openstack_networking_subnet_v2" "ms-subnet" {
+  name          ="${ var.short_name }-subnet"
+  network_id    = "${ openstack_networking_network_v2.ms-network.id }"
+  cidr          = "${ var.subnet_cidr }"
+  ip_version    = "${ var.ip_version }"
+}
+
+resource "openstack_networking_router_v2" "ms-router" {
+  name             = "${ var.short_name }-router"
+  external_gateway = "${ var.external_net_id }"
+}
+
+resource "openstack_networking_router_interface_v2" "ms-router-interface" {
+  router_id = "${ openstack_networking_router_v2.ms-router.id }"
+  subnet_id = "${ openstack_networking_subnet_v2.ms-subnet.id }"
+}


### PR DESCRIPTION
Give users the option of using an alternate sample for OpenStack
depending on whether they want to use a private network with floating
IPs or a public network.