### PR TITLE
upgrade-packages.yml cleans yum prior to upgrading

### DIFF
--- a/playbooks/upgrade-packages.yml
+++ b/playbooks/upgrade-packages.yml
@@ -4,6 +4,10 @@
   serial: "{{ serial | default(1) }}"
   tasks:
 
+  - name: clean yum
+    sudo: yes
+    command: yum clean all
+
   - name: refresh yum cache
     sudo: yes
     command: yum makecache


### PR DESCRIPTION
playbooks/upgrade-packages.yml has been edited to run `yum clean all` prior to refreshing the cache or making any upgrades.