### PR TITLE
Remove NetworkManager from Vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,24 +22,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.synced_folder ".", "/vagrant", type: "rsync"
 
-  config.vm.network :forwarded_port, guest: 2181,  host: 2181  # ZooKeeper
-  config.vm.network :forwarded_port, guest: 4400,  host: 4400  # Chronos
-  config.vm.network :forwarded_port, guest: 5050,  host: 5050  # Mesos leader
-  config.vm.network :forwarded_port, guest: 15050, host: 15050 # Mesos leader UI
-  config.vm.network :forwarded_port, guest: 5051,  host: 5051  # Mesos follower
-  config.vm.network :forwarded_port, guest: 8080,  host: 8080  # Marathon
-  config.vm.network :forwarded_port, guest: 18080, host: 18080 # Marathon UI
-  config.vm.network :forwarded_port, guest: 8500,  host: 8500  # Consul
-  config.vm.network :forwarded_port, guest: 8600,  host: 8600  # Consul DNS
-
-  # Mesos task ports
-  for i in 4000..5000
-    config.vm.network :forwarded_port, guest: i, host: i
-  end
-
-  for i in 31000..32000
-    config.vm.network :forwarded_port, guest: i, host: i
-  end
+  config.vm.network "private_network", :ip => "192.168.242.55"
 
   config.vm.provision "shell" do |s|
     s.path = "vagrant/provision.sh"

--- a/img-build/packer/kickstarts/vagrant.ks
+++ b/img-build/packer/kickstarts/vagrant.ks
@@ -8,6 +8,7 @@ keyboard us
 lang en_US.UTF-8
 timezone --utc Etc/UTC
 
+services --disabled=avahi-daemon,tuned,postfix,polkit,NetworkManager --enabled=network
 network --device=enp0s3 --bootproto=dhcp --ipv6=auto --activate
 selinux --permissive
 firewall --disabled
@@ -25,8 +26,9 @@ repo --name="base"      --baseurl=http://mirror.centos.org/centos/7/os/x86_64
 repo --name="updates"   --baseurl=http://mirror.centos.org/centos/7/updates/x86_64
 
 %packages --nobase --ignoremissing --excludedocs
-@core
+@core --nodefaults
 -*firmware
+-NetworkManager*
 %end
 
 reboot

--- a/img-build/packer/scripts/dnsmasq.sh
+++ b/img-build/packer/scripts/dnsmasq.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
 
-yum install -y dnsmasq bind-utils NetworkManager
+yum install -y dnsmasq bind-utils
 
 # EOF

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -40,17 +40,6 @@
   tags:
     - dnsmasq
 
-- name: configure networkmanager for dnsmasq
-  sudo: yes
-  lineinfile:
-    dest: /etc/NetworkManager/NetworkManager.conf
-    line: "dns=none"
-    insertafter: "^\\[main\\]$"
-  notify:
-    - restart networkmanager
-  tags:
-    - dnsmasq
-
 - name: add dnsmasq to /etc/resolv.conf
   sudo: yes
   lineinfile:

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -14,4 +14,8 @@ if [ ! -f /vagrant/security.yml ]; then
 fi
 
 hostname default
+
+# Hack to make ansible use the right iface for ansible_default_ipv4.address
+# In vagrant, this should be the third interface after loopback and nat.
+ip route add 8.8.8.8/32 via `hostname -I | cut -d ' ' -f 2` dev `ip link | grep '^3: ' | cut -d ':' -f 2`
 ansible-playbook vagrant.yml -e @security.yml -i /vagrant/vagrant/vagrant-inventory


### PR DESCRIPTION
NetworkManager is problematic in Vagrant environments since it will
tear down hostonly private networks as soon as they are created by
the vagrant provisioner. This patch removes it as it's included in
@core by default.

Partially addresses #256 #503 