### PR TITLE
dockerfile ssh: support passphrase and any key name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,14 @@ RUN mkdir -p /tmp/terraform/ && \
     yum remove -y unzip && \
     yum -y clean all
 
-# load microservices-infrastructure and default setup
-COPY . /mi/
-
 # install all dependencies
+COPY requirements.txt /mi/
 RUN yum install -y epel-release
 RUN yum install -y python-pip python-crypto openssl openssh-clients && \
     pip install -U -r /mi/requirements.txt
+
+# load microservices-infrastructure and default setup
+COPY . /mi/
 
 # load user custom setup
 ONBUILD COPY ssl/ /mi/ssl/

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ONBUILD COPY terraform.yml /mi/terraform.yml
 ONBUILD COPY *.tf /mi/
 
 RUN mkdir -p /state
-VOLUME /state
+VOLUME /state /ssh
 
 WORKDIR /mi
 CMD ["/mi/docker_launch.sh"]

--- a/docker_launch.sh
+++ b/docker_launch.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 set -e
 
+SSH_KEY=${SSH_KEY:-"/root/.ssh/id_rsa"}
+
+eval `ssh-agent -s` && ssh-add $SSH_KEY
+
 if [ ! -f ./security.yml ]; then
     ./security-setup --enable=false
 fi
 
 terraform get
 terraform apply -state=$TERRAFORM_STATE_ROOT/terraform.tfstate
-ansible-playbook /mi/playbooks/wait-for-hosts.yml
-ansible-playbook /mi/terraform.yml --extra-vars=@security.yml
+ansible-playbook /mi/playbooks/wait-for-hosts.yml --private-key $SSH_KEY
+ansible-playbook /mi/terraform.yml --extra-vars=@security.yml --private-key $SSH_KEY

--- a/docker_launch.sh
+++ b/docker_launch.sh
@@ -3,6 +3,10 @@ set -e
 
 SSH_KEY=${SSH_KEY:-"/root/.ssh/id_rsa"}
 
+mkdir -p /root/.ssh/
+find /ssh/* ! -type l -print0 | xargs -0 cp -t /root/.ssh/
+chown root:root /root/.ssh/*
+
 eval `ssh-agent -s` && ssh-add $SSH_KEY
 
 if [ ! -f ./security.yml ]; then

--- a/docs/getting_started/dockerfile.rst
+++ b/docs/getting_started/dockerfile.rst
@@ -65,13 +65,13 @@ easily access the ``terraform.tfstate`` file to use for future Terraform runs.
 
 Now we can use this information to run our container:
 
-``docker run -it -v ~/.ssh/:/root/.ssh/ -v $PWD:/state mi``
+``docker run -it -v ~/.ssh/:/ssh/ -v $PWD:/state mi``
 
 As discussed above, we are launching a container from the `mi` image we created
-earlier and are host mounting our local ``~/.ssh/`` directory to the container
-user's ``.ssh`` directory. And we are mounting our current directory to the
-container's ``/state`` volume. Therefore, the ``terraform.tfstate`` files will be
-accessible from our local host directory after the run. Note that we are also
+earlier and are host mounting our local ``~/.ssh/`` directory to a volume on the
+container called ``/ssh``. And we are mounting our current directory to the
+container's ``/state`` volume. Therefore, the ``terraform.tfstate`` files will
+be accessible from our local host directory after the run. Note that we are also
 allocating a TTY for the container process (using ``-it``) so that we can enter
 our SSH key passphrase if necessary.
 
@@ -83,4 +83,4 @@ Terraform template, and custom playbook that you configured in the Setup above.
           corresponding private key as an environment variable (``SSH_KEY``)
           when running the container. For example:
 
-          ``docker run -it -e SSH_KEY=/root/.ssh/otherpvtkey -v ~/.ssh/:/root/.ssh/ -v $PWD:/state mi``
+          ``docker run -it -e SSH_KEY=/root/.ssh/otherpvtkey -v ~/.ssh/:/ssh/ -v $PWD:/state mi``

--- a/docs/getting_started/dockerfile.rst
+++ b/docs/getting_started/dockerfile.rst
@@ -50,8 +50,8 @@ directory (along with a corresponding private key). Terraform uses this to
 authorize your key on the cluster nodes that it creates. This provides you with
 SSH access to the nodes which is required for the subsequent Ansible
 provisioning. The simplest way to handle this when running from a Docker
-container is to host mount your ``~/.ssh`` folder in the container. You will see
-an example of this later in the document.
+container is to mount your ``~/.ssh`` folder in the container. You will see an
+example of this later in the document.
 
 Another important thing to understand is how Terraform manages `state
 <https://terraform.io/docs/state/index.html>`_. Terraform uses a `JSON`
@@ -59,21 +59,21 @@ formatted file to store the state of your managed infrastructure. This state
 file is important as it will allow you to use Terraform to plan, inspect, modify
 and destroy resources in your infrastructure. By default, Terraform writes state
 to a file called ``terraform.tfstate`` in the same directory where you launched
-Terraform. Our ``Dockerfile`` is configured to store the state in a Docker volume
-called ``/state``. This will allow you to host mount that volume so that you can
-easily access the ``terraform.tfstate`` file to use for future Terraform runs.
+Terraform. Our ``Dockerfile`` is configured to store the state in a Docker
+volume called ``/state``. This will allow you to mount that volume so that you
+can easily access the ``terraform.tfstate`` file to use for future Terraform
+runs.
 
 Now we can use this information to run our container:
 
 ``docker run -it -v ~/.ssh/:/ssh/ -v $PWD:/state mi``
 
-As discussed above, we are launching a container from the `mi` image we created
-earlier and are host mounting our local ``~/.ssh/`` directory to a volume on the
-container called ``/ssh``. And we are mounting our current directory to the
-container's ``/state`` volume. Therefore, the ``terraform.tfstate`` files will
-be accessible from our local host directory after the run. Note that we are also
-allocating a TTY for the container process (using ``-it``) so that we can enter
-our SSH key passphrase if necessary.
+As discussed above we are launching a container from the ``mi`` image we created
+earlier, while mounting our local ``~/.ssh/`` to ``/ssh`` in the container, and
+our current directory to the container's ``/state``. Therefore, the
+``terraform.tfstate`` files will be accessible from our local host directory
+after the run. Note that we are also allocating a TTY for the container process
+(using ``-it``) so that we can enter our SSH key passphrase if necessary.
 
 The container should launch and provision the cluster using the ``security.yml``,
 Terraform template, and custom playbook that you configured in the Setup above.

--- a/docs/getting_started/dockerfile.rst
+++ b/docs/getting_started/dockerfile.rst
@@ -45,12 +45,12 @@ Now we can run a container from our image to provision a new cluster. Before we
 do that, there are a couple of things to understand.
 
 By default, our Terraform templates are configured with the assumption that you
-have an SSH public key called `id_rsa.pub` in the `.ssh` folder of your home
+have an SSH public key called ``id_rsa.pub`` in the ``.ssh`` folder of your home
 directory (along with a corresponding private key). Terraform uses this to
 authorize your key on the cluster nodes that it creates. This provides you with
 SSH access to the nodes which is required for the subsequent Ansible
 provisioning. The simplest way to handle this when running from a Docker
-container is to host mount your `~/.ssh` folder in the container. You will see
+container is to host mount your ``~/.ssh`` folder in the container. You will see
 an example of this later in the document.
 
 Another important thing to understand is how Terraform manages `state
@@ -58,20 +58,29 @@ Another important thing to understand is how Terraform manages `state
 formatted file to store the state of your managed infrastructure. This state
 file is important as it will allow you to use Terraform to plan, inspect, modify
 and destroy resources in your infrastructure. By default, Terraform writes state
-to a file called `terraform.tfstate` in the same directory where you launched
-Terraform. Our `Dockerfile` is configured to store the state in a Docker volume
-called `/state`. This will allow you to host mount that volume so that you can
-easily access the `terraform.tfstate` file to use for future Terraform runs.
+to a file called ``terraform.tfstate`` in the same directory where you launched
+Terraform. Our ``Dockerfile`` is configured to store the state in a Docker volume
+called ``/state``. This will allow you to host mount that volume so that you can
+easily access the ``terraform.tfstate`` file to use for future Terraform runs.
 
 Now we can use this information to run our container:
 
-``docker run -v ~/.ssh/:/root/.ssh/ -v $PWD:/state mi``
+``docker run -it -v ~/.ssh/:/root/.ssh/ -v $PWD:/state mi``
 
 As discussed above, we are launching a container from the `mi` image we created
-earlier and are host mounting our local `~/.ssh/` directory to the container
-user's `.ssh` directory. And we are mounting our current directory to the
-container's `/state` volume. Therefore, the `terraform.tfstate` files will be
-accessible from our local host directory after the run.
+earlier and are host mounting our local ``~/.ssh/`` directory to the container
+user's ``.ssh`` directory. And we are mounting our current directory to the
+container's ``/state`` volume. Therefore, the ``terraform.tfstate`` files will be
+accessible from our local host directory after the run. Note that we are also
+allocating a TTY for the container process (using ``-it``) so that we can enter
+our SSH key passphrase if necessary.
 
-The container should launch and provision the cluster using the `security.yml`,
+The container should launch and provision the cluster using the ``security.yml``,
 Terraform template, and custom playbook that you configured in the Setup above.
+
+.. note:: If you have customized your Terraform template to use a different SSH
+          public key than the default ``~/.ssh/id_rsa.pub``, you can specify the
+          corresponding private key as an environment variable (``SSH_KEY``)
+          when running the container. For example:
+
+          ``docker run -it -e SSH_KEY=/root/.ssh/otherpvtkey -v ~/.ssh/:/root/.ssh/ -v $PWD:/state mi``


### PR DESCRIPTION
The experience running a build from a docker container wasn't great if you had a passphrase-protected ssh key. Also, there was no way to build a cluster if you used a key other than one named ~/.ssh/id_rsa. This should fix both of those issues.