### PR TITLE
Typo error in mesos/nginx-proxy.yml

### DIFF
--- a/roles/mesos/tasks/nginx-proxy.yml
+++ b/roles/mesos/tasks/nginx-proxy.yml
@@ -30,11 +30,12 @@
       dest: /usr/lib/systemd/system/nginx-mesos-leader.service
     - src: nginx-mesos-leader.env.j2
       dest: /etc/default/nginx-mesos-leader.env
-  tags:
-    - mesos
-  tags:
+  notify:
     - reload nginx-mesos-leader
     - restart nginx-mesos-leader
+  tags:
+    - mesos
+
 
 - name: enable nginx-mesos-leader
   sudo: yes


### PR DESCRIPTION
There was a duplicate tags instruction which should be a notify.