### PR TITLE
Kafka-mesos: remove host fqdn dependency

### DIFF
--- a/roles/kafka-mesos/tasks/client.yml
+++ b/roles/kafka-mesos/tasks/client.yml
@@ -12,7 +12,7 @@
 - name: Add Kafka brockers  
   run_once: true
   sudo: true
-  command: "./kafka-mesos.sh add  0..{{ kafka_brokers - 1 }} --heap {{ kafka_broker_heap }} --mem {{ kafka_broker_memory }} --api http://{{ ansible_hostname }}:7000"
+  command: "./kafka-mesos.sh add  0..{{ kafka_brokers - 1 }} --heap {{ kafka_broker_heap }} --mem {{ kafka_broker_memory }} --api http://{{ kafka_scheduler_hostname }}:7000"
   args:
     chdir: "{{ kafka_mesos_install_dir }}"
   tags:
@@ -21,7 +21,7 @@
 - name: Start Kafka brockers  
   run_once: true
   sudo: true
-  command: "./kafka-mesos.sh start 0..{{ kafka_brokers - 1 }} --api http://{{ ansible_hostname }}:7000"
+  command: "./kafka-mesos.sh start 0..{{ kafka_brokers - 1 }} --api http://{{ kafka_scheduler_hostname }}:7000"
   args:
     chdir: "{{ kafka_mesos_install_dir }}"
   tags:

--- a/roles/kafka-mesos/tasks/main.yml
+++ b/roles/kafka-mesos/tasks/main.yml
@@ -45,7 +45,7 @@
 - include: scheduler.yml
   when: kafka_downloaded | changed
 
-- include: client.yml
-  when: kafka_downloaded | changed
+#- include: client.yml
+#  when: kafka_downloaded | changed
 
 - include: config.yml

--- a/roles/kafka-mesos/templates/kafka.json.j2
+++ b/roles/kafka-mesos/templates/kafka.json.j2
@@ -12,5 +12,6 @@
     "cpus": 1,
     "mem": 2048,
     "cmd": "./kafka-mesos.sh scheduler --master=zk://{{ zookeeper_master }}:2181/mesos --zk={{ zookeeper_master }}:2181 --api=http://{{ kafka_scheduler_hostname }}:7000 --storage=zk:/kafka-mesos",
-    "instances": 1
+    "instances": 1,
+    "constraints": [["hostname", "LIKE", "{{ ansible_hostname }}"]]
 }

--- a/roles/kafka-mesos/templates/kafka.json.j2
+++ b/roles/kafka-mesos/templates/kafka.json.j2
@@ -11,7 +11,6 @@
     "id":"kafka-mesos-scheduler",
     "cpus": 1,
     "mem": 2048,
-    "cmd": "./kafka-mesos.sh scheduler --master=zk://{{ zookeeper_master }}:2181/mesos --zk={{ zookeeper_master }}:2181 --api=http://{{ ansible_hostname }}:7000 --storage=zk:/kafka-mesos",
-    "instances": 1,
-    "constraints": [["hostname", "LIKE", "{{ ansible_hostname }}"]]
+    "cmd": "./kafka-mesos.sh scheduler --master=zk://{{ zookeeper_master }}:2181/mesos --zk={{ zookeeper_master }}:2181 --api=http://{{ kafka_scheduler_hostname }}:7000 --storage=zk:/kafka-mesos",
+    "instances": 1
 }

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -31,5 +31,5 @@ consul_nginx_image_tag: 1.1
 # jobs
 mesos_consul_image: drifting/mesos-consul
 mesos_consul_image_tag: latest
-marathon_consul_image: brianhicks/marathon-consul
-marathon_consul_image_tag: latest
+marathon_consul_image: ciscocloud/marathon-consul
+marathon_consul_image_tag: 0.1


### PR DESCRIPTION
Start brockers using consul-dns record instead hardcoded node fqdn