### PR TITLE
logstash: optionally specify elasticsearch output

### DIFF
--- a/roles/logstash/README.rst
+++ b/roles/logstash/README.rst
@@ -14,6 +14,24 @@ You can use these variables to customize your Logstash installations:
 
    Default: false
 
+.. data :: logstash_output_elasticsearch
+
+   Configures an elasticsearch output for the local Logstash agent on all nodes.
+   You can set this variable to a dictionary that maps to the `Logstash
+   Elasticsearch output
+   <https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html>`_
+   settings.
+
+   Default: n/a
+
+   Example:
+
+.. code-block:: yaml
+
+   logstash_output_elasticsearch:
+     host: "elasticsearch.example.com"
+     protocol: "http"
+
 .. data :: logstash_input_log4j
 
    Read events over a TCP socket from a Log4j SocketAppender

--- a/roles/logstash/templates/logstash.conf.j2
+++ b/roles/logstash/templates/logstash.conf.j2
@@ -34,6 +34,13 @@ input {
 }
 
 output {
+{% if logstash_output_elasticsearch is defined %}
+  elasticsearch {
+  {% for key, val in logstash_output_elasticsearch.iteritems() %}
+    {{ key }} => {{ val | to_nice_json }}
+  {% endfor %}
+  }
+{% endif %}
 {% if logstash_output_stdout %}
   stdout {
     codec => rubydebug


### PR DESCRIPTION
Example: set the following in your playbook

```
   logstash_output_elasticsearch:
     host: "elasticsearch.example.com"
     protocol: "http"
```