### PR TITLE
Fix consul service name

### DIFF
--- a/roles/consul/files/distributive-consul-config.json
+++ b/roles/consul/files/distributive-consul-config.json
@@ -1,6 +1,6 @@
 {
   "service": {
-    "name": "Distributive check - Consul",
+    "name": "distributive",
     "check": {
       "script": "/usr/bin/distributive -f /usr/share/distributive/consul.json",
       "interval": "10m"


### PR DESCRIPTION
There cannot be spaces in consul service names. The service was incorrectly registered with its health check name instead of its service name.