### PR TITLE
Error detection in firewalld

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -37,6 +37,8 @@
     name: firewalld
     enabled: false
     state: stopped
+  register: command_result
+  failed_when: "command_result|failed and 'No such file or directory' not in command_result.msg"  
 
 - name: enable EPEL repo
   sudo: yes


### PR DESCRIPTION
My CentOS 7 version that I had didn't have firewalld installed so the ansible script failed.  I updated the common role so that if firewalld is not installed it won't error out if it tries to disable a service that isn't there. 