### PR TITLE
Corrected distributive ansible tasks for consul

### DIFF
--- a/roles/consul/tasks/distributive.yml
+++ b/roles/consul/tasks/distributive.yml
@@ -16,17 +16,16 @@
   copy:
     src: distributive-consul-check.json
     dest: /etc/distributive.d/consul.json
-    mode: 0664
-    owner: root
-    group: root
+  when: consul_servers_group | match("role=control")
   tags:
-    - distributive
+    - consul
 
 - name: register distributive tests with consul
   sudo: yes
   copy:
     src: distributive-consul-config.json
     dest: /etc/consul
+  when: consul_servers_group | match("role=control")
   notify:
     - reload consul
   tags:
@@ -35,7 +34,7 @@
 
 - name: run distributive consul test
   sudo: yes
-  command: /usr/bin/distributive -f /etc/distributive.d/consul.json
+  command: /usr/bin/distributive -f /usr/share/distributive/consul.json
   tags:
     - consul
     - distributive

--- a/roles/consul/tasks/distributive.yml
+++ b/roles/consul/tasks/distributive.yml
@@ -16,7 +16,7 @@
   copy:
     src: distributive-consul-check.json
     dest: /etc/distributive.d/consul.json
-  when: consul_servers_group | match("role=control")
+  when: "'{{ consul_servers_group}}' in group_names"
   tags:
     - consul
 
@@ -25,7 +25,7 @@
   copy:
     src: distributive-consul-config.json
     dest: /etc/consul
-  when: consul_servers_group | match("role=control")
+  when: "'{{ consul_servers_group}}' in group_names"
   notify:
     - reload consul
   tags:


### PR DESCRIPTION
I've changed the role/consul/tasks/distributive.yml so that it only installs and registers the consul test if it is a control node. This is to correct #540. 

It will still run the consul checks a single time to verify the initial install is correct. 

Testing has only been done via vagrant, however I modified the vagrant.yml playbook so that it will have the consul_servers_group variable set as `role=worker` as it would via the terraform playbook. 