### PR TITLE
All consul checks must have timeouts

### DIFF
--- a/roles/chronos/templates/chronos-consul.j2
+++ b/roles/chronos/templates/chronos-consul.j2
@@ -5,7 +5,8 @@
     "port": 14400,
     "check": {
       "script": "curl --silent --show-error --fail --dump-header /dev/stderr --retry 2 http://127.0.0.1:14400/ping",
-      "interval": "10s"
+      "interval": "10s",
+      "timeout": "1s"
     }
   }
 }

--- a/roles/consul/files/distributive-consul-config.json
+++ b/roles/consul/files/distributive-consul-config.json
@@ -4,6 +4,7 @@
     "name": "Distributive Consul Health Checks",
     "service_id": "consul",
     "script": "/bin/distributive -f /etc/distributive.d/consul.json",
-    "interval": "1m"
+    "interval": "1m",
+    "timeout": "30s"
   }
 }

--- a/roles/consul/files/docker-service.json
+++ b/roles/consul/files/docker-service.json
@@ -3,7 +3,8 @@
     "name": "docker",
     "check": {
       "script": "/usr/local/bin/check-service-active docker",
-      "interval": "15s"
+      "interval": "15s",
+      "timeout": "2s"
     }
   }
 }

--- a/roles/marathon/templates/marathon-consul.j2
+++ b/roles/marathon/templates/marathon-consul.j2
@@ -5,7 +5,8 @@
     "port": 18080,
     "check": {
       "script": "curl --silent --show-error --fail --dump-header /dev/stderr --retry 2 {% if marathon_http_credentials is defined %}-u {{ marathon_http_credentials }}{% endif %} http://127.0.0.1:18080/ping",
-      "interval": "10s"
+      "interval": "10s",
+      "timeout": "2s"
     }
   }
 }

--- a/roles/zookeeper/templates/zk-consul.json.j2
+++ b/roles/zookeeper/templates/zk-consul.json.j2
@@ -6,7 +6,8 @@
     "port": 2181,
     "check": {
       "script": "/usr/local/bin/zookeeper_check.sh",
-      "interval": "10s"
+      "interval": "10s",
+      "timeout": "2s"
     }
   }
 }


### PR DESCRIPTION
Previously, the checks were defined without
a timeout, which led to thousands of processes
spawned by consul. This would worsen the
health of an already unstable cluster.

In particular, the curl command by default has
no timeout, and will hang if it successfully
opens a TCP connection but receives no data.