### PR TITLE
attempting to improve recovery of a cluster post-reboot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alabaster==0.6.3
-ansible>=1.9.0,<1.9.1
+ansible>=1.9.1,<2.0
 pytest==2.7.1
 PyYAML==3.11
 Sphinx==1.2.3

--- a/roles/chronos/tasks/main.yml
+++ b/roles/chronos/tasks/main.yml
@@ -47,6 +47,19 @@
   tags:
     - chronos
 
+- name: configure chronos to wait for zookeeper before starting
+  sudo: yes
+  lineinfile:
+    dest: /usr/lib/systemd/system/chronos.service
+    line: "ExecStartPre=/bin/bash -c '(echo > /dev/tcp/{{ chronos_zk_dns }}/{{ chronos_zk_port }}) &> /dev/null'"
+    insertbefore: "^ExecStart="
+    state: present
+  notify:
+    - reload chronos
+    - restart chronos
+  tags:
+    - chronos
+
 - name: fix chronos bin file
   sudo: yes
   replace:

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -12,6 +12,32 @@
     - dnsmasq
     - bootstrap
 
+- name: collect nameservers
+  sudo: yes
+  shell: "cat /etc/resolv.conf | grep -i '^nameserver' | cut -d ' ' -f2"
+  register: nameservers_output
+  tags:
+    - dnsmasq
+
+- name: collect dns search list
+  sudo: yes
+  shell: "cat /etc/resolv.conf | grep -i '^search' | cut -d ' ' -f2- | tr ' ' '\n'"
+  register: dns_search_list_output
+  tags:
+    - dnsmasq
+
+- name: set nameservers
+  set_fact:
+    nameservers: "{{ nameservers_output.stdout_lines }}"
+  tags:
+    - dnsmasq
+
+- name: set dns search list
+  set_fact:
+    domain_search_list: "{{ dns_search_list_output.stdout_lines }}"
+  tags:
+    - dnsmasq
+
 - name: ensure dnsmasq.d directory exists
   sudo: yes
   file: 
@@ -53,10 +79,10 @@
 
 - name: add dnsmasq to /etc/resolv.conf
   sudo: yes
-  lineinfile:
+  template:
+    src: resolv.conf.j2
     dest: /etc/resolv.conf
-    line: "search {{ consul_dns_domain }}\nnameserver 127.0.0.1"
-    insertbefore: BOF
+    mode: 644
   tags:
     - dnsmasq
 

--- a/roles/dnsmasq/templates/10-consul
+++ b/roles/dnsmasq/templates/10-consul
@@ -19,3 +19,10 @@ server=/{{ consul_dns_domain }}/{{ hostvars[host].ansible_default_ipv4.address }
 {% endif %}
 {% endfor %}
 
+{% if ansible_domain is defined and ansible_domain != '' %}
+{% for nameserver in nameservers | unique %}
+{% if nameserver != '127.0.0.1' %}
+server=/{{ ansible_domain }}/{{ nameserver }}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/roles/dnsmasq/templates/resolv.conf.j2
+++ b/roles/dnsmasq/templates/resolv.conf.j2
@@ -1,0 +1,7 @@
+search {{ [consul_dns_domain] | union(domain_search_list) | unique | join(' ') }}
+nameserver 127.0.0.1
+{% for nameserver in nameservers | unique %}
+{% if nameserver != '127.0.0.1' %}
+nameserver {{ nameserver }}
+{% endif %}
+{% endfor %}

--- a/roles/marathon/tasks/main.yml
+++ b/roles/marathon/tasks/main.yml
@@ -40,7 +40,18 @@
   tags:
     - marathon
 
-- meta: flush_handlers
+- name: configure marathon to wait for zookeeper before starting
+  sudo: yes
+  lineinfile:
+    dest: /usr/lib/systemd/system/marathon.service
+    line: "ExecStartPre=/bin/bash -c '(echo > /dev/tcp/{{ marathon_zk_dns }}/{{ marathon_zk_port }}) &> /dev/null'"
+    insertbefore: "^ExecStart="
+    state: present
+  notify:
+    - reload marathon
+    - restart marathon
+  tags:
+    - marathon
 
 - meta: flush_handlers
 


### PR DESCRIPTION
* ensure zookeeper is available before starting marathon and chronos (fixes #533)
* preserve internal dns resolution (improves #538 but #544 also needed)
* require at least ansible 1.9.1 so that services can properly be enabled/disabled (fixes #549) 