### PR TITLE
[TASK] Make docker_launch flexible

### DIFF
--- a/docker_launch.sh
+++ b/docker_launch.sh
@@ -3,8 +3,10 @@ set -e
 
 SSH_KEY=${SSH_KEY:-"/root/.ssh/id_rsa"}
 
-mkdir -p /root/.ssh/
-find /ssh/* ! -type l -print0 | xargs -0 cp -t /root/.ssh/
+if [ ! -f "$SSH_KEY" ]; then
+    mkdir -p /root/.ssh/
+    find /ssh/* ! -type l -print0 | xargs -0 cp -t /root/.ssh/
+fi
 chown root:root /root/.ssh/*
 
 eval `ssh-agent -s` && ssh-add $SSH_KEY


### PR DESCRIPTION
If the SSH_KEY already exists then no need to check the /ssh/ volume
for keys, so we can skip this step.

closes: #555