### PR TITLE
zk container - manage zk cls with zkcli and add certs

### DIFF
--- a/roles/chronos/defaults/main.yml
+++ b/roles/chronos/defaults/main.yml
@@ -9,11 +9,11 @@ chronos_zk_connect: "zk://{{chronos_zk_auth}}{{ chronos_zk_dns }}:{{ chronos_zk_
 chronos_zk_mesos_master: "zk://{{ chronos_zk_dns }}:{{ chronos_zk_port }}/mesos"
 
 # zookeeper
-zk_docker_image: "ciscocloud/zookeeper:0.2"
+zk_docker_image: "ciscocloud/zookeeper:0.3"
 chronos_zk_acl_world: "world:anyone:cdrwa"
 chronos_zk_acl: "{% if zk_chronos_user_secret is defined %}digest:{{ zk_chronos_user }}:{{ zk_chronos_user_secret_digest}}:cdraw{% endif  %}"
 
-chronos_zk_acl_cmd: "docker run --rm -e ZK_AUTH=super:{{ zk_super_user_secret }} -e ZNODE=/{{ chronos_zk_chroot }} -e ZNODE_ACL={{ chronos_zk_acl_world }},{{ chronos_zk_acl }} -e ZK_SERVER={{ chronos_zk_dns }}:{{ chronos_zk_port }} --entrypoint /usr/local/bin/setacl.sh {{ zk_docker_image }}"
+chronos_zk_acl_cmd: "docker run --rm --entrypoint zookeepercli {{ zk_docker_image }} -servers {{ chronos_zk_dns }}:{{ chronos_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ chronos_zk_chroot }} '{{ chronos_zk_acl_world }},{{ chronos_zk_acl }}'"
 
 chronos_port: 14400
 chronos_proxy_port: 4400

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -5,11 +5,11 @@ marathon_zk_port: 2181
 marathon_zk_chroot: marathon
 marathon_zk_connect: "zk://{{ marathon_zk_auth}}{{ marathon_zk_dns }}:{{ marathon_zk_port }}/{{ marathon_zk_chroot }}"
 
-zk_docker_image: "ciscocloud/zookeeper:0.2"
+zk_docker_image: "ciscocloud/zookeeper:0.3"
 marathon_zk_acl_world: "world:anyone:cdrwa"
 marathon_zk_acl: "{% if zk_marathon_user_secret is defined %}digest:{{ zk_marathon_user }}:{{ zk_marathon_user_secret_digest}}:cdraw{% endif  %}"
 
-marathon_zk_acl_cmd: "docker run --rm -e ZK_AUTH=super:{{ zk_super_user_secret }} -e ZNODE=/{{ marathon_zk_chroot }} -e ZNODE_ACL={{ marathon_zk_acl_world }},{{ marathon_zk_acl }} -e ZK_SERVER={{ marathon_zk_dns }}:{{ marathon_zk_port }} --entrypoint /usr/local/bin/setacl.sh {{ zk_docker_image }}"
+marathon_zk_acl_cmd: "docker run --rm --entrypoint zookeepercli {{ zk_docker_image }} -servers {{ marathon_zk_dns }}:{{ marathon_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ marathon_zk_chroot }} '{{ marathon_zk_acl_world }},{{ marathon_zk_acl }}'"
 
 marathon_http_credentials: ""
 marathon_keystore_path: ""

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -15,13 +15,13 @@ mesos_zk_auth: "{% if zk_mesos_user_secret is defined %}{{ zk_mesos_user }}:{{ z
 mesos_zk_dns: "zookeeper.service.{{ consul_dns_domain }}"
 mesos_zk_port: 2181
 mesos_zk_chroot: mesos
-zk_docker_image: "ciscocloud/zookeeper:0.2"
+zk_docker_image: "ciscocloud/zookeeper:0.3"
 mesos_leaders_group: role=control
 
 mesos_zk_acl_world: "world:anyone:r"
 mesos_zk_acl: "{% if zk_mesos_user_secret is defined %}digest:{{ zk_mesos_user }}:{{ zk_mesos_user_secret_digest}}:cdraw{% endif %}"
 
-mesos_zk_acl_cmd: "docker run --rm -e ZK_AUTH=super:{{ zk_super_user_secret }} -e ZNODE=/{{ mesos_zk_chroot }} -e ZNODE_ACL={{ mesos_zk_acl_world }},{{ mesos_zk_acl }} -e ZK_SERVER={{ mesos_zk_dns }}:{{ mesos_zk_port }} --entrypoint /usr/local/bin/setacl.sh {{ zk_docker_image }}"
+mesos_zk_acl_cmd: "docker run --rm --entrypoint zookeepercli {{ zk_docker_image }} -servers {{ mesos_zk_dns }}:{{ mesos_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ mesos_zk_chroot }} '{{ mesos_zk_acl_world }},{{ mesos_zk_acl }}'"
 
 # authentication options
 mesos_credentials: []

--- a/roles/zookeeper/defaults/main.yml
+++ b/roles/zookeeper/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-zookeeper_image: ciscocloud/zookeeper
-zookeeper_image_tag: 0.2
+zookeeper_image: "ciscocloud/zookeeper"
+zookeeper_image_tag: 0.3
 zookeeper_ports: "-p 2181:2181 -p 2888:2888 -p 3888:3888"
 zookeeper_env: "/etc/default/{{ zookeeper_service }}"
 

--- a/roles/zookeeper/templates/zookeeper-service.j2
+++ b/roles/zookeeper/templates/zookeeper-service.j2
@@ -24,6 +24,7 @@ ExecStart=/usr/bin/docker run \
     --env-file={{ zookeeper_env }} \
     --volumes-from {{ zookeeper_data_volume }} \
     --volume=/var/log/zookeeper:/var/log/zookeeper \
+    --volume=/etc/consul/ssl/:/usr/local/share/ca-certificates/:ro \
     {{ zookeeper_image }}:{{ zookeeper_image_tag }}
 
 ExecStop=/bin/bash -c " \


### PR DESCRIPTION
* uses new version of zookeeper container with zookeepercli built in
* uses zookeepercli to set zk acls instead of the setacl.sh script (https://github.com/CiscoCloud/microservices-infrastructure/issues/329).
* zookeeper-service systemd unit has been updated to use the certificates in /etc/consul/ssl for ssl validation.

Note that the zookeeper container includes an updated version of consul-template (v0.10.0) which has a bug (https://github.com/hashicorp/consul-template/issues/321) where it ignores some command line flags such as `--ssl-verify`. To mitigate this (and for better ssl support in general), the zookeeper container now allows you to mount a host volume with certificates to use for ssl verification.