### PR TITLE
Decode errors in security-setup before printing

### DIFF
--- a/security-setup
+++ b/security-setup
@@ -373,10 +373,10 @@ class Component(object):
         print('exit status: {}'.format(status))
         if stdout:
             print(' stdout '.center(40, '~'))
-            print(stdout)
+            print(stdout.decode('utf-8'))
         if stderr:
             print(' stderr '.center(40, '~'))
-            print(stderr)
+            print(stderr.decode('utf-8'))
 
     def wrap_call(self, command, **kwargs):
         status, out, err = self.call(command, **kwargs)


### PR DESCRIPTION
Fixes #536. Doesn't need testing on cloud deployments or anything, just run ./security-setup locally. 