### PR TITLE
Add support for SoftLayer

### DIFF
--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -29,6 +29,7 @@ platforms:
    aws.rst
    digitalocean.rst
    vsphere.rst
+   softlayer.rst
 
 Setting up Authentication and Authorization
 -------------------------------------------

--- a/docs/getting_started/softlayer.rst
+++ b/docs/getting_started/softlayer.rst
@@ -1,0 +1,56 @@
+SoftLayer
+=========
+
+.. versionadded:: 0.3.3
+
+As of microservices-infrastructure 0.3.3 you can bring up SoftLayer
+servers using Terraform. microservices-infrastructure uses Terraform to
+provision hosts.
+
+As of now, the released version of Terraform doesn't have SoftLayer support,
+but one can build a `custom binary with SoftLayer provisioning.<https://github.com/hashicorp/terraform/pull/2554>`.
+
+Configuring Terraform for SoftLayer
+-----------------------------------
+
+Before we can build any servers using Terraform and Ansible, we need to
+configure authentication. We'll be filling in the authentication variables for
+the template located at ``terraform/softlayer.sample.tf``. It looks like this:
+
+.. this is highlighted as javascript for convenience, but obviously that's not
+   the *real* language.
+.. literalinclude:: ../../terraform/softlayer.sample.tf
+   :language: javascript
+
+Copy that file in it's entirety to the root of the project to start
+customization. In the next sections, we'll describe the settings that you need
+to configure.
+
+Username and API Key
+^^^^^^^
+
+You need to generate an API key for your SoftLayer account. This can be done
+in the control panel at `http://softlayer.com<http://softlayer.com>`.
+
+This token, along with your username, must be put in your softlayer.tf file.
+Alternatively, if you don't want to put credentials in the terraform file,
+you can set environment variables:
+
+.. envvar:: SOFTLAYER_USERNAME
+
+   The SoftLayer username
+
+.. envvar:: SOFTLAYER_API_KEY
+
+  The SoftLayer API key
+
+
+Provisioning
+------------
+
+Once you're all set up with the provider, customize your modules (for
+``control_count`` and ``worker_count``), run ``terraform get`` to prepare
+Terraform to provision your cluster, ``terraform plan`` to see what will be
+created, and ``terraform apply`` to provision the cluster. Afterwards, you can
+use the instructions in :doc:`getting started <index>` to install
+microservices-infrastructure on your new cluster.

--- a/terraform/softlayer.sample.tf
+++ b/terraform/softlayer.sample.tf
@@ -1,0 +1,17 @@
+provider "softlayer" {
+}
+
+module "softlayer-keypair" {
+  source = "./terraform/softlayer/keypair"
+  public_key_filename = "~/.ssh/id_rsa.pub"
+}
+
+module "softlayer-hosts" {
+  source = "./terraform/softlayer/hosts"
+  ssh_key = "${module.softlayer-keypair.keypair_id}"
+
+  region_name = "ams01"
+  domain = "example.com"
+  control_count = 1
+  worker_count = 3
+}

--- a/terraform/softlayer/hosts/main.tf
+++ b/terraform/softlayer/hosts/main.tf
@@ -1,0 +1,36 @@
+# input variables
+variable control_count { default = 1 }
+variable control_size { default = 4096 }
+variable datacenter { default = "mi" }
+variable domain { default = "example.com" }
+variable image_name { default = "CENTOS_7_64" }
+variable region_name { default = "ams01" }
+variable short_name { default = "mi" }
+variable ssh_key { }
+variable worker_count { default = 3 }
+variable worker_size { default = 4096 }
+
+# create resources
+resource "softlayer_virtualserver" "control" {
+  count = "${var.control_count}"
+  name = "${var.short_name}-control-${format("%02d", count.index+1)}"
+  domain = "${var.domain}"
+  image = "${var.image_name}"
+  region = "${var.region_name}"
+  ram = "${var.control_size}"
+  cpu = 1
+  ssh_keys = ["${var.ssh_key}"]
+  user_data = "{\"role\":\"control\",\"dc\":\"${var.datacenter}\"}"
+}
+
+resource "softlayer_virtualserver" "worker" {
+  count = "${var.worker_count}"
+  name = "${var.short_name}-worker-${format("%03d", count.index+1)}"
+  domain = "${var.domain}"
+  image = "${var.image_name}"
+  region = "${var.region_name}"
+  ram = "${var.worker_size}"
+  cpu = 1
+  ssh_keys = ["${var.ssh_key}"]
+  user_data = "{\"role\":\"worker\",\"dc\":\"${var.datacenter}\"}"
+}

--- a/terraform/softlayer/keypair/main.tf
+++ b/terraform/softlayer/keypair/main.tf
@@ -1,0 +1,14 @@
+# input variables
+variable short_name { default = "mi" }
+variable public_key_filename { default = "~/.ssh/id_rsa.pub" }
+
+# create resources
+resource "softlayer_ssh_key" "default" {
+  name = "${var.short_name}-key"
+  public_key = "${file(var.public_key_filename)}"
+}
+
+# output variables
+output "keypair_id" {
+  value = "${softlayer_ssh_key.default.id}"
+}


### PR DESCRIPTION
This adds .tf files for SoftLayer virtual guests,
and a simple .tf file for using them.
The change also depends on terraform.py being updated
so that it can read the inventory list from softlayer.tfstate.