### PR TITLE
Use zookeeper-wait-for-listen to check if zookeeper is up

### DIFF
--- a/roles/chronos/tasks/main.yml
+++ b/roles/chronos/tasks/main.yml
@@ -51,7 +51,7 @@
   sudo: yes
   lineinfile:
     dest: /usr/lib/systemd/system/chronos.service
-    line: "ExecStartPre=/bin/bash -c '(echo > /dev/tcp/{{ chronos_zk_dns }}/{{ chronos_zk_port }}) &> /dev/null'"
+    line: "ExecStartPre=/usr/local/bin/zookeeper-wait-for-listen.sh {{ chronos_zk_dns }}"
     insertbefore: "^ExecStart="
     state: present
   notify:


### PR DESCRIPTION
In a Vagrant build, sometimes zookeeper is occasionally not available when Chronos is restarted. 