### PR TITLE
Fix a few haproxy issues

### DIFF
--- a/roles/haproxy/README.rst
+++ b/roles/haproxy/README.rst
@@ -3,7 +3,7 @@ Haproxy
 
 .. versionadded:: 0.2
 
-`Haproxy <haproxy https://github.com/CiscoCloud/haproxy-consul>`_ connects to
+`Haproxy <https://github.com/CiscoCloud/haproxy-consul>`_ connects to
 :doc:`consul`, and proxies all registered services. At the current time all
 containers are mapped to port 80. Future versions will allow each container to
 control the haproxy port and url mapping.

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -9,4 +9,4 @@ haproxy_domain: example.com
 
 haproxy_env: /etc/default/haproxy
 
-haproxy_args: "/launch.sh -ssl -ssl-verify=false"
+haproxy_args: "/launch.sh{% if do_consul_ssl %} -ssl -ssl-verify=false{% endif %}"

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -161,6 +161,20 @@ resource "aws_security_group" "worker" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress { # HTTP
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress { # HTTPS
+    from_port = 443
+    to_port = 443
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   ingress { # Mesos
     from_port = 5050
     to_port = 5050

--- a/terraform/gce/gce.tf
+++ b/terraform/gce/gce.tf
@@ -32,6 +32,8 @@ resource "google_compute_firewall" "mi-firewall-external" {
     ports = [
       "22",   # SSH
       "3389", # RDP
+      "80",   # HTTP
+      "443",  # HTTPs
       "4400", # Chronos
       "5050", # Mesos
       "8080", # Marathon


### PR DESCRIPTION
* haproxy was broken when Consul SSL was disabled. It should now work whether Consul SSL is enabled or not
* opens HTTP/S ports on AWS and GCE 
* fixes a broken link in the haproxy role's README