### PR TITLE
Zookeeper consul check fix

### DIFF
--- a/roles/zookeeper/files/zookeeper_check.sh
+++ b/roles/zookeeper/files/zookeeper_check.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-[[ "$(echo ruok | nc "$HOSTNAME" 2181 2>/dev/null)" == "imok" ]] && exit 0 || exit 1
+[[ -n "$1" ]] && host=$1 || host=$HOSTNAME
+
+[[ "$(echo ruok | nc "$host" 2181 2>/dev/null)" == "imok" ]] && exit 0 || exit 1

--- a/roles/zookeeper/templates/zk-consul.json.j2
+++ b/roles/zookeeper/templates/zk-consul.json.j2
@@ -5,7 +5,7 @@
     "id": "2181:zkid-{{ zookeeper_id }}",
     "port": 2181,
     "check": {
-      "script": "/usr/local/bin/zookeeper_check.sh",
+      "script": "/usr/local/bin/zookeeper_check.sh {{ inventory_hostname }}",
       "interval": "10s",
       "timeout": "2s"
     }


### PR DESCRIPTION
The zk checker script originally rely on `$HOSTNAME`. This will not work in all cases. I've modified to the script to optionally accept `host` as an argument and modified the consul check to use `inventory_hostname` when using the `zk_checker.sh` script.