### PR TITLE
GlusterFS

### DIFF
--- a/docs/components/glusterfs.rst
+++ b/docs/components/glusterfs.rst
@@ -1,0 +1,1 @@
+.. include:: ../../roles/glusterfs/README.rst

--- a/docs/components/index.rst
+++ b/docs/components/index.rst
@@ -11,6 +11,7 @@ which can be customized, generally using Ansible variables.
    consul.rst
    dnsmasq.rst
    docker.rst
+   glusterfs.rst
    haproxy.rst
    logstash.rst
    marathon.rst

--- a/roles/glusterfs/README.rst
+++ b/roles/glusterfs/README.rst
@@ -20,11 +20,11 @@ mounted properly at ``/data``::
 Cloud Configuration
 -------------------
 
-On Google Compute Engine and Amazon Web Services, the
+On Google Compute Engine, Amazon Web Services, and OpenStack the
 microservices-infrastructure Terraform modules will create an external volume.
-By default, this volume will be 500gb, but you can change this with the
-``glusterfs_volume_size`` variable. The attached disk will be formatted as an
-XFS volume and mounted on the control nodes.
+By default, this volume will be 100gb, but you can change this with the
+Terraform ``glusterfs_volume_size`` variable. The attached disk will be
+formatted as an XFS volume and mounted on the control nodes.
 
 Variables
 ---------

--- a/roles/glusterfs/README.rst
+++ b/roles/glusterfs/README.rst
@@ -29,6 +29,13 @@ XFS volume and mounted on the control nodes.
 Variables
 ---------
 
+.. data:: glusterfs_mode
+
+   The mode that GlusterFS will be configured in. Valid values: "server" and
+   "client".
+
+   default: ``client``
+
 .. data:: glusterfs_replication
 
    The amount of replication to use for new volumes. Should be a factor of the

--- a/roles/glusterfs/README.rst
+++ b/roles/glusterfs/README.rst
@@ -1,0 +1,87 @@
+GlusterFS
+=========
+
+.. versionadded:: 0.4
+
+`Gluster <http://www.gluster.org/>`_ implements a distributed filesystem. It is
+used for container volume management and syncing around the cluster.
+
+Use with Docker
+---------------
+
+Any Docker volume should be able to access data inside the
+``/mnt/container-volumes`` partition. Because of SELinux, the volume label needs
+to be updated within the container. You can use the ``z`` flag to do this, as in
+this example which will open up a prompt in a container where the volume is
+mounted properly at ``/data``::
+
+    docker run --rm -it -v /mnt/container-volumes/test:/data:z gliderlabs/alpine /bin/sh
+
+Cloud Configuration
+-------------------
+
+On Google Compute Engine and Amazon Web Services, the
+microservices-infrastructure Terraform modules will create an external volume.
+By default, this volume will be 500gb, but you can change this with the
+``glusterfs_volume_size`` variable. The attached disk will be formatted as an
+XFS volume and mounted on the control nodes.
+
+Variables
+---------
+
+.. data:: glusterfs_replication
+
+   The amount of replication to use for new volumes. Should be a factor of the
+   number of nodes in the server group
+
+   default: the number of control nodes present in the server group
+
+.. data:: glusterfs_server_group
+
+   A selector for a group to use as Gluster servers.
+
+   default: ``role=control``
+
+.. data:: glusterfs_brick_mount
+
+   Where the Gluster external disk will be mounted on supported cloud providers.
+
+   default: ``/mnt/glusterfs``
+
+.. data:: glusterfs_brick_device
+
+   Automatically calculated depending on which cloud provider you are using.
+   This should only be changed if you're adding support for a new cloud provider
+   or know very well where your volume is going to be located.
+
+   default: automatically generated
+
+.. data:: glusterfs_volume_force
+
+   Whether the glusterfs volume should be force-created (that is, created with
+   storage on the root partition.) This is true when not using a cloud provider
+   that supports external block storage.
+
+   default: automatically generated "yes" or "no"
+
+.. data:: glusterfs_brick_location
+
+   The area in the filesystem to store bricks. It defaults to the value of
+   ``glusterfs_brick_mount`` if an external disk is mounted, and
+   ``/etc/glusterfs/data`` otherwise.
+
+   default: automatically generated
+
+.. data:: glusterfs_container_data_name
+
+   The name of the Gluster container in which you plan to store container
+   volumes.
+
+   default: ``container-volumes``
+
+.. data:: glusterfs_container_data_mount
+
+   Where to mount the container data volume. Defaults to the name of the volume
+   under ``/mnt/``
+
+   default: automatically generated

--- a/roles/glusterfs/defaults/main.yml
+++ b/roles/glusterfs/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+glusterfs_replication: "{{ groups[glusterfs_server_group] | count }}"
+glusterfs_server_data_location: /etc/glusterfs/data
+glusterfs_server_group: role=control
+glusterfs_volumes: ["docker"]

--- a/roles/glusterfs/defaults/main.yml
+++ b/roles/glusterfs/defaults/main.yml
@@ -4,7 +4,7 @@ glusterfs_server_group: role=control
 
 # brick storage
 glusterfs_brick_mount: /mnt/glusterfs
-glusterfs_brick_device: "{% if provider == 'gce' %}/dev/disk/by-id/google-glusterfs{% endif %}"
+glusterfs_brick_device: "{% if provider == 'gce' %}/dev/disk/by-id/google-glusterfs{% elif provider == 'aws' %}/dev/xvdh{% endif %}"
 glusterfs_volume_force: "{% if glusterfs_brick_device %}no{% else %}yes{% endif %}"
 glusterfs_brick_location: "{% if glusterfs_brick_device %}{{ glusterfs_brick_mount }}{% else %}/etc/glusterfs/data{% endif %}"
 

--- a/roles/glusterfs/defaults/main.yml
+++ b/roles/glusterfs/defaults/main.yml
@@ -2,4 +2,7 @@
 glusterfs_replication: "{{ groups[glusterfs_server_group] | count }}"
 glusterfs_server_data_location: /etc/glusterfs/data
 glusterfs_server_group: role=control
-glusterfs_volumes: ["docker"]
+
+# docker volume
+glusterfs_container_data_name: container-volumes
+glusterfs_container_data_mount: /mnt/{{ glusterfs_container_data_name }}

--- a/roles/glusterfs/defaults/main.yml
+++ b/roles/glusterfs/defaults/main.yml
@@ -1,7 +1,12 @@
 ---
 glusterfs_replication: "{{ groups[glusterfs_server_group] | count }}"
-glusterfs_server_data_location: /etc/glusterfs/data
 glusterfs_server_group: role=control
+
+# brick storage
+glusterfs_brick_mount: /mnt/glusterfs
+glusterfs_brick_device: "{% if provider == 'gce' %}/dev/disk/by-id/google-glusterfs{% endif %}"
+glusterfs_volume_force: "{% if glusterfs_brick_device %}no{% else %}yes{% endif %}"
+glusterfs_brick_location: "{% if glusterfs_brick_device %}{{ glusterfs_brick_mount }}{% else %}/etc/glusterfs/data{% endif %}"
 
 # docker volume
 glusterfs_container_data_name: container-volumes

--- a/roles/glusterfs/defaults/main.yml
+++ b/roles/glusterfs/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+glusterfs_mode: client
 glusterfs_replication: "{{ groups[glusterfs_server_group] | count }}"
 glusterfs_server_group: role=control
 

--- a/roles/glusterfs/defaults/main.yml
+++ b/roles/glusterfs/defaults/main.yml
@@ -5,7 +5,7 @@ glusterfs_server_group: role=control
 
 # brick storage
 glusterfs_brick_mount: /mnt/glusterfs
-glusterfs_brick_device: "{% if provider == 'gce' %}/dev/disk/by-id/google-glusterfs{% elif provider == 'aws' %}/dev/xvdh{% endif %}"
+glusterfs_brick_device: "{% if provider == 'gce' %}/dev/disk/by-id/google-glusterfs{% elif provider == 'aws' %}/dev/xvdh{% elif provider == 'openstack' %}/dev/vdb{% endif %}"
 glusterfs_volume_force: "{% if glusterfs_brick_device %}no{% else %}yes{% endif %}"
 glusterfs_brick_location: "{% if glusterfs_brick_device %}{{ glusterfs_brick_mount }}{% else %}/etc/glusterfs/data{% endif %}"
 

--- a/roles/glusterfs/handlers/main.yml
+++ b/roles/glusterfs/handlers/main.yml
@@ -5,3 +5,7 @@
     - systemctl daemon-reload
     - systemctl restart glusterd
     - systemctl restart glusterfsd
+
+- name: reload consul
+  sudo: yes
+  command: "consul reload"

--- a/roles/glusterfs/handlers/main.yml
+++ b/roles/glusterfs/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: reload glusterfs
+  sudo: yes
   command: "{{ item }}"
   with_items:
     - systemctl daemon-reload

--- a/roles/glusterfs/handlers/main.yml
+++ b/roles/glusterfs/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: reload glusterfs
+  command: "{{ item }}"
+  with_items:
+    - systemctl daemon-reload
+    - systemctl restart glusterd
+    - systemctl restart glusterfsd

--- a/roles/glusterfs/tasks/client.yml
+++ b/roles/glusterfs/tasks/client.yml
@@ -1,0 +1,20 @@
+---
+- name: create mount point for container volume
+  sudo: yes
+  file:
+    state: directory
+    name: "{{ glusterfs_container_data_mount }}"
+    recurse: yes
+    mode: 0755
+  tags:
+    - glusterfs
+
+- name: mount container volume
+  sudo: yes
+  mount:
+    state: mounted
+    name: "{{ glusterfs_container_data_mount }}"
+    fstype: glusterfs
+    src: "fs.glusterfs.service.{{ consul_dns_domain }}:/{{ glusterfs_container_data_name }}"
+  tags:
+    - glusterfs

--- a/roles/glusterfs/tasks/main.yml
+++ b/roles/glusterfs/tasks/main.yml
@@ -1,18 +1,14 @@
 ---
 # TODO: external volume + formatting
 
-- name: ensure server data location is present
-  sudo: yes
-  file:
-    state: directory
-    path: "{{ glusterfs_server_data_location }}"
-
 - name: enable glusterfs community repo
   sudo: yes
   get_url:
     url: https://download.gluster.org/pub/gluster/glusterfs/LATEST/CentOS/glusterfs-epel.repo
     dest: /etc/yum.repos.d/glusterfs-epel.repo
     sha256sum: 11e24f4c7ea04cf51c38c7a8c5b24f3e0298c50f6119c4b58af207fedf85652e
+  tags:
+    - glusterfs
 
 - name: install glusterfs packages
   sudo: yes
@@ -21,42 +17,11 @@
     state: present
   with_items:
     - glusterfs
-    - glusterfs-cli
     - glusterfs-fuse
-    - glusterfs-server
-  notify:
-    - reload glusterfs
+  tags:
+    - glusterfs
 
-- name: start gluster services
-  sudo: yes
-  command: systemctl start {{ item }}
-  with_items:
-    - glusterd
-    - glusterfsd
+- include: server.yml
+  when: glusterfs_mode == "server"
 
-- name: probe servers
-  run_once: true
-  sudo: yes
-  command: gluster peer probe {{ item }}.node.{{ consul_dns_domain }}
-  with_items: groups[glusterfs_server_group]
-
-- name: create gluster_volume script
-  sudo: yes
-  template:
-    src: gluster_volume.sh.j2
-    dest: /etc/glusterfs/gluster_volume.sh
-    mode: 755
-
-- name: create gluserfs volumes
-  run_once: true
-  sudo: yes
-  command: /etc/glusterfs/gluster_volume.sh {{ item }}
-  with_items: glusterfs_volumes
-
-- name: start glusterfs volumes
-  sudo: yes
-  run_once: true
-  gluster_volume:
-    name: "{{ item }}"
-    state: started
-  with_items: glusterfs_volumes
+- include: client.yml

--- a/roles/glusterfs/tasks/main.yml
+++ b/roles/glusterfs/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+# TODO: external volume + formatting
+
+- name: ensure server data location is present
+  sudo: yes
+  file:
+    state: directory
+    path: "{{ glusterfs_server_data_location }}"
+
+- name: enable glusterfs community repo
+  sudo: yes
+  get_url:
+    url: https://download.gluster.org/pub/gluster/glusterfs/LATEST/CentOS/glusterfs-epel.repo
+    dest: /etc/yum.repos.d/glusterfs-epel.repo
+    sha256sum: 11e24f4c7ea04cf51c38c7a8c5b24f3e0298c50f6119c4b58af207fedf85652e
+
+- name: install glusterfs packages
+  sudo: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - glusterfs
+    - glusterfs-cli
+    - glusterfs-fuse
+    - glusterfs-server
+  notify:
+    - reload glusterfs
+
+- name: start gluster services
+  sudo: yes
+  command: systemctl start {{ item }}
+  with_items:
+    - glusterd
+    - glusterfsd
+
+- name: probe servers
+  run_once: true
+  sudo: yes
+  command: gluster peer probe {{ item }}.node.{{ consul_dns_domain }}
+  with_items: groups[glusterfs_server_group]
+
+- name: create glusterfs volumes
+  run_once: true
+  sudo: yes
+  gluster_volume:
+    brick: "{{ glusterfs_server_data_location }}/{{ item }}"
+    force: true # TODO: separate partitions so we don't have to do this
+    name: "{{ item }}"
+    rebalance: yes
+    replicas: "{{ glusterfs_replication }}"
+    state: present
+  with_items: glusterfs_volumes
+
+- name: start glusterfs volumes
+  sudo: yes
+  run_once: true
+  gluster_volume:
+    name: "{{ item }}"
+    state: started
+  with_items: glusterfs_volumes

--- a/roles/glusterfs/tasks/main.yml
+++ b/roles/glusterfs/tasks/main.yml
@@ -1,7 +1,5 @@
 ---
-# TODO: external volume + formatting
-
-- name: enable glusterfs community repo
+- name: enable community repo
   sudo: yes
   get_url:
     url: https://download.gluster.org/pub/gluster/glusterfs/LATEST/CentOS/glusterfs-epel.repo
@@ -10,7 +8,7 @@
   tags:
     - glusterfs
 
-- name: install glusterfs packages
+- name: install packages
   sudo: yes
   yum:
     name: "{{ item }}"

--- a/roles/glusterfs/tasks/main.yml
+++ b/roles/glusterfs/tasks/main.yml
@@ -40,16 +40,17 @@
   command: gluster peer probe {{ item }}.node.{{ consul_dns_domain }}
   with_items: groups[glusterfs_server_group]
 
-- name: create glusterfs volumes
+- name: create gluster_volume script
+  sudo: yes
+  template:
+    src: gluster_volume.sh.j2
+    dest: /etc/glusterfs/gluster_volume.sh
+    mode: 755
+
+- name: create gluserfs volumes
   run_once: true
   sudo: yes
-  gluster_volume:
-    brick: "{{ glusterfs_server_data_location }}/{{ item }}"
-    force: true # TODO: separate partitions so we don't have to do this
-    name: "{{ item }}"
-    rebalance: yes
-    replicas: "{{ glusterfs_replication }}"
-    state: present
+  command: /etc/glusterfs/gluster_volume.sh {{ item }}
   with_items: glusterfs_volumes
 
 - name: start glusterfs volumes

--- a/roles/glusterfs/tasks/server.yml
+++ b/roles/glusterfs/tasks/server.yml
@@ -1,0 +1,111 @@
+---
+- name: format brick disk
+  sudo: yes
+  filesystem:
+    dev: "{{ glusterfs_brick_device }}"
+    fstype: xfs
+    opts: "-i size=512"
+  when: glusterfs_brick_device != ""
+  tags:
+    - glusterfs
+    - disk
+
+- name: create mount point for brick disk
+  sudo: yes
+  file:
+    state: directory
+    name: "{{ glusterfs_brick_mount }}"
+    recurse: yes
+    mode: 0755
+  when: glusterfs_brick_device != ""
+  tags:
+    - glusterfs
+    - disk
+
+- name: mount brick disk
+  sudo: yes
+  mount:
+    state: mounted
+    name: "{{ glusterfs_brick_mount }}"
+    fstype: xfs
+    src: "{{ glusterfs_brick_device }}"
+    dump: 1
+    passno: 2
+  tags:
+    - glusterfs
+    - disk
+
+- name: ensure brick location is present
+  sudo: yes
+  file:
+    state: directory
+    path: "{{ glusterfs_brick_location }}"
+  tags:
+    - glusterfs
+
+- name: install server packages
+  sudo: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - glusterfs-cli
+    - glusterfs-server
+  notify:
+    - reload glusterfs
+  tags:
+    - glusterfs
+
+- name: start services
+  sudo: yes
+  command: systemctl start {{ item }}
+  with_items:
+    - glusterd
+    - glusterfsd
+  tags:
+    - glusterfs
+
+- name: probe servers
+  run_once: true
+  sudo: yes
+  command: gluster peer probe {{ item }}.node.{{ consul_dns_domain }}
+  with_items: groups[glusterfs_server_group]
+  tags:
+    - glusterfs
+
+- name: create gluster_volume script
+  sudo: yes
+  template:
+    src: gluster_volume.sh.j2
+    dest: /etc/glusterfs/gluster_volume.sh
+    mode: 755
+  tags:
+    - glusterfs
+
+- name: create container volume
+  run_once: true
+  sudo: yes
+  command: /etc/glusterfs/gluster_volume.sh {{ glusterfs_container_data_name }}
+  tags:
+    - glusterfs
+
+- name: start container volume
+  sudo: yes
+  run_once: true
+  gluster_volume:
+    name: "{{ glusterfs_container_data_name }}"
+    state: started
+  tags:
+    - glusterfs
+
+- name: create consul service
+  sudo: yes
+  template:
+    src: glusterfs.json.j2
+    dest: /etc/consul/glusterfs.json
+  notify:
+    - reload consul
+  tags:
+    - glusterfs
+
+- meta: flush_handlers

--- a/roles/glusterfs/templates/gluster_volume.sh.j2
+++ b/roles/glusterfs/templates/gluster_volume.sh.j2
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+NAME=$1
+
+if ! gluster volume list | grep -q $NAME; then
+    gluster volume create $NAME \
+            replica {{ glusterfs_replication }} \
+            {% for server in groups[glusterfs_server_group] %}{{ server }}.node.{{ consul_dns_domain }}:{{ glusterfs_server_data_location }}/$NAME {% endfor %} \
+            force # TODO: separate partitions so we don't have to do this
+else
+    echo "volume already created"
+fi

--- a/roles/glusterfs/templates/gluster_volume.sh.j2
+++ b/roles/glusterfs/templates/gluster_volume.sh.j2
@@ -5,8 +5,7 @@ NAME=$1
 if ! gluster volume list | grep -q $NAME; then
     gluster volume create $NAME \
             replica {{ glusterfs_replication }} \
-            {% for server in groups[glusterfs_server_group] %}{{ server }}.node.{{ consul_dns_domain }}:{{ glusterfs_server_data_location }}/$NAME {% endfor %} \
-            force # TODO: separate partitions so we don't have to do this
+            {% for server in groups[glusterfs_server_group] %}{{ server }}.node.{{ consul_dns_domain }}:{{ glusterfs_brick_location }}/$NAME {% endfor %}{% if glusterfs_volume_force == "yes" %}force{% endif %};
 else
-    echo "volume already created"
-fi
+    echo "volume already created";
+fi;

--- a/roles/glusterfs/templates/glusterfs.json.j2
+++ b/roles/glusterfs/templates/glusterfs.json.j2
@@ -1,0 +1,16 @@
+{
+    "services": [
+        {
+            "name": "glusterfs",
+            "tags": ["fs"],
+            "port": 24007,
+            "id": "24007:glusterfs-{{ inventory_hostname }}"
+        },
+        {
+            "name": "glusterfs",
+            "tags": ["infiniband"],
+            "port": 24008,
+            "id": "24008:glusterfs-{{ inventory_hostname }}"
+        }
+    ]
+}

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -81,3 +81,20 @@
     - mesos
     - marathon
     - chronos
+
+# GlusterFS has to be provisioned in reverse order from Mesos: servers then
+# clients.
+- hosts: role=control
+  gather_facts: no
+  vars:
+    consul_dns_domain: consul
+    glusterfs_mode: server
+  roles:
+    - glusterfs
+
+- hosts: role=worker
+  vars:
+    consul_dns_domain: consul
+    glusterfs_mode: client
+  roles:
+    - glusterfs

--- a/terraform/openstack.sample.tf
+++ b/terraform/openstack.sample.tf
@@ -1,26 +1,25 @@
 module "dc2-keypair" {
-	source = "./terraform/openstack/keypair"
-	auth_url = ""
-	tenant_id = ""
-	tenant_name = ""
-	public_key = ""
-	keypair_name = ""
+  source = "./terraform/openstack/keypair"
+  auth_url = ""
+  tenant_id = ""
+  tenant_name = ""
+  public_key = ""
+  keypair_name = ""
 }
 
 module "dc2-hosts" {
-	source = "./terraform/openstack/hosts"
-	auth_url = ""
-	datacenter = "dc2"
-	tenant_id = ""
-	tenant_name = ""
-	control_flavor_name = ""
-	resource_flavor_name  = ""
-	net_id = ""
-	image_name = ""
-	keypair_name = "${ module.dc2-keypair.keypair_name }"
-	control_count = 2
-	resource_count = 3
-	security_groups = ""
-    glusterfs_volume_size = 100
-    device_name = "/dev/vdb"
+  source = "./terraform/openstack/hosts"
+  auth_url = ""
+  datacenter = "dc2"
+  tenant_id = ""
+  tenant_name = ""
+  control_flavor_name = ""
+  resource_flavor_name  = ""
+  net_id = ""
+  image_name = ""
+  keypair_name = "${ module.dc2-keypair.keypair_name }"
+  control_count = 2
+  resource_count = 3
+  security_groups = ""
+  glusterfs_volume_size = 100
 }

--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -21,6 +21,16 @@ provider "openstack" {
   tenant_name	= "${ var.tenant_name }"
 }
 
+resource "openstack_blockstorage_volume_v1" "mi-control-glusterfs" {
+  name = "${ var.short_name }-control-glusterfs-${format("%02d", count.index+1) }"
+  description = "${ var.short_name }-control-glusterfs-${format("%02d", count.index+1) }"
+  size = "${ var.glusterfs_volume_size }"
+  metadata = {
+    usage = "container-volumes"
+  }
+  count = "${ var.control_count }"
+}
+
 resource "openstack_compute_instance_v2" "control" {
   name = "${ var.short_name}-control-${format("%02d", count.index+1) }"
   key_pair = "${ var.keypair_name }"
@@ -28,8 +38,8 @@ resource "openstack_compute_instance_v2" "control" {
   flavor_name = "${ var.control_flavor_name }"
   security_groups = [ "${ var.security_groups }" ]
   network = { uuid  = "${ var.net_id }" }
-  volume {
-    volume_id = "${ element(openstack_blockstorage_volume_v1.mi-control-glusterfs.*.id, count.index) }"
+  volume = {
+    volume_id = "${element(openstack_blockstorage_volume_v1.mi-control-glusterfs.*.id, count.index)}"
     device = "/dev/vdb"
   }
   metadata = {
@@ -53,14 +63,4 @@ resource "openstack_compute_instance_v2" "resource" {
     ssh_user = "${ var.ssh_user }"
   }
   count = "${ var.resource_count }"
-}
-
-resource "openstack_blockstorage_volume_v1" "mi-control-glusterfs" {
-  name = "${ var.short_name }-control-glusterfs-${format("%02d", count.index+1) }"
-  description = "${ var.short_name }-control-glusterfs-${format("%02d", count.index+1) }"
-  size = "${ var.glusterfs_volume_size }"
-  metadata = {
-    usage = "container-volumes"
-  }
-  count = "${ var.control_count }"
 }

--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -1,20 +1,19 @@
 variable auth_url { }
+variable control_count {}
+variable control_flavor_name { }
 variable datacenter { default = "openstack" }
 variable glusterfs_volume_size { default = "100" } # size is in gigabytes
-variable device_name { default = "/dev/vdb" }
-variable tenant_id { }
-variable tenant_name { }
-variable control_flavor_name { }
-variable resource_flavor_name { }
-variable net_id { }
-variable keypair_name { }
 variable image_name { }
-variable control_count {}
+variable keypair_name { }
+variable long_name { default = "microservices-infrastructure" }
+variable net_id { }
 variable resource_count {}
+variable resource_flavor_name { }
 variable security_groups { default = "default" }
 variable short_name { default = "mi" }
-variable long_name { default = "microservices-infrastructure" }
 variable ssh_user { default = "centos" }
+variable tenant_id { }
+variable tenant_name { }
 
 provider "openstack" {
   auth_url = "${ var.auth_url }"
@@ -30,14 +29,14 @@ resource "openstack_compute_instance_v2" "control" {
   security_groups = [ "${ var.security_groups }" ]
   network = { uuid  = "${ var.net_id }" }
   volume {
-        volume_id = "${ element(openstack_blockstorage_volume_v1.mi-control-glusterfs.*.id, count.index) }"
-        device = "${ var.device_name }"
+    volume_id = "${ element(openstack_blockstorage_volume_v1.mi-control-glusterfs.*.id, count.index) }"
+    device = "/dev/vdb"
   }
   metadata = {
-     dc = "${var.datacenter}"
-     role = "control"
-     ssh_user = "${ var.ssh_user }"
-   }
+    dc = "${var.datacenter}"
+    role = "control"
+    ssh_user = "${ var.ssh_user }"
+  }
   count = "${ var.control_count }"
 }
 
@@ -52,7 +51,7 @@ resource "openstack_compute_instance_v2" "resource" {
     dc = "${var.datacenter}"
     role = "worker"
     ssh_user = "${ var.ssh_user }"
-   }
+  }
   count = "${ var.resource_count }"
 }
 
@@ -61,7 +60,7 @@ resource "openstack_blockstorage_volume_v1" "mi-control-glusterfs" {
   description = "${ var.short_name }-control-glusterfs-${format("%02d", count.index+1) }"
   size = "${ var.glusterfs_volume_size }"
   metadata = {
-     usage = "container-volumes"
-   }
+    usage = "container-volumes"
+  }
   count = "${ var.control_count }"
 }


### PR DESCRIPTION
This PR adds GlusterFS to the control nodes. It also creates and mounts a Gluster volume at `/mnt/container-volumes` for containers to use, and documents the use of the volume in Docker.

GCE and AWS will mount an external data location for bricks. I couldn't get OpenStack to work correctly, so it's omitted. @kenjones-cisco, if you've got working terraform modules for this I'd love to see them to get this in.

Feedback on all of this is very welcome.

Closes #567