### PR TITLE
openstack terraform changes for mounting block devices for used with glusterfs

### DIFF
--- a/terraform/openstack.sample.tf
+++ b/terraform/openstack.sample.tf
@@ -21,4 +21,6 @@ module "dc2-hosts" {
 	control_count = 2
 	resource_count = 3
 	security_groups = ""
+    glusterfs_volume_size = 100
+    device_name = "/dev/vdb"
 }


### PR DESCRIPTION
An example from one of my roles on how used made use of the block devices:

```
- name: create a virtual group named vgdata on device /dev/vdb
  sudo: yes
  lvg:
    vg=vgdata
    pvs=/dev/vdb
    state=present

- name: create a logical volume named lvdata01 in vgdata
  sudo: yes
  lvol:
    vg=vgdata
    lv=lvdata01
    size=100%FREE
    state=present

- name: create an ext4 filesystem in /dev/mapper/vgdata-lvdata01
  sudo: yes
  filesystem:
    fstype=ext4
    dev=/dev/mapper/vgdata-lvdata01

- name: mount data filesystem
  sudo: yes
  mount:
    name=/srv/gluster/data
    src=/dev/mapper/vgdata-lvdata01
    fstype=ext4
    state=mounted

- name: start GlusterFS service
  sudo: yes
  service:
    name=glusterd
    state=started

# in near-term "brick" will be changed to "bricks" with an alias "brick"
- name: create database gluster volume
  sudo: yes
  run_once: true
  gluster_volume:
    host="{{ inventory_hostname }}"
    brick=/srv/gluster/data/brick
    force=true
    cluster={{ groups[mongodb_server_group] | join(",") }}
    replicas={{ groups[mongodb_server_group] | length }}
    name=dbgv0
    state=present

- name: start database gluster volume
  sudo: yes
  gluster_volume:
    name=dbgv0
    state=started

- name: create database data directory
  sudo: yes
  file:
    name="{{ mongodb_mount_path }}"
    state=directory

- name: mount the database data directory
  sudo: yes
  mount:
    name="{{ mongodb_mount_path }}"
    src=localhost:/dbgv0
    fstype=glusterfs
    state=mounted
```