### PR TITLE
Fix/vagrant private network

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ vagrant up
 
 Note:
 * There is no support for Windows at this time, however support is planned.
+* Vagrant 1.7.3+ is required for best results.
 * There is no support for the VMware Fusion Vagrant provider; hence your provider is set to Virtualbox in your Vagrantfile. In order to start running just issue the `vagrant up` command.
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,8 @@ def load_security
   YAML.load_file(fname)
 end
 
+VAGRANT_PRIVATE_IP = "192.168.242.55"
+
 Vagrant.configure(2) do |config|
 
   # Prefer VirtualBox before VMware Fusion
@@ -21,28 +23,11 @@ Vagrant.configure(2) do |config|
   config.vm.box = "CiscoCloud/microservices-infrastructure"
 
   config.vm.synced_folder ".", "/vagrant", type: "rsync"
-
-  config.vm.network :forwarded_port, guest: 2181,  host: 2181  # ZooKeeper
-  config.vm.network :forwarded_port, guest: 4400,  host: 4400  # Chronos
-  config.vm.network :forwarded_port, guest: 5050,  host: 5050  # Mesos leader
-  config.vm.network :forwarded_port, guest: 15050, host: 15050 # Mesos leader UI
-  config.vm.network :forwarded_port, guest: 5051,  host: 5051  # Mesos follower
-  config.vm.network :forwarded_port, guest: 8080,  host: 8080  # Marathon
-  config.vm.network :forwarded_port, guest: 18080, host: 18080 # Marathon UI
-  config.vm.network :forwarded_port, guest: 8500,  host: 8500  # Consul
-  config.vm.network :forwarded_port, guest: 8600,  host: 8600  # Consul DNS
-
-  # Mesos task ports
-  for i in 4000..5000
-    config.vm.network :forwarded_port, guest: i, host: i
-  end
-
-  for i in 31000..32000
-    config.vm.network :forwarded_port, guest: i, host: i
-  end
+  config.vm.network "private_network", :ip => VAGRANT_PRIVATE_IP
 
   config.vm.provision "shell" do |s|
     s.path = "vagrant/provision.sh"
+    s.args = VAGRANT_PRIVATE_IP
   end
 
   config.vm.provider :virtualbox do |vb|

--- a/roles/chronos/templates/nginx-chronos.env.j2
+++ b/roles/chronos/templates/nginx-chronos.env.j2
@@ -1,7 +1,7 @@
 NGINX_KV=service/nginx/templates/chronos
 NGINX_AUTH_TYPE=basic
 NGINX_AUTH_BASIC_KV=service/nginx/auth/users
-NGINX_PUBLIC_IP={{ ansible_default_ipv4.address }}
+NGINX_PUBLIC_IP={{ private_ipv4 }}
 CONSUL_CONNECT=consul.service.consul:8500
 {% if do_consul_ssl|bool %}
 CONSUL_SSL=true

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -13,10 +13,10 @@
   sudo: yes
   lineinfile:
     dest: /etc/hosts
-    regexp: "^{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}{% if use_host_domain %} {{ item }}.{{ host_domain }}{% endif %}$"
-    line: "{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}{% if use_host_domain %} {{ item }}.{{ host_domain}}{% endif %}"
+    regexp: "^{{ hostvars[item].private_ipv4 }} {{ item }}{% if use_host_domain %} {{ item }}.{{ host_domain }}{% endif %}$"
+    line: "{{ hostvars[item].private_ipv4 }} {{ item }}{% if use_host_domain %} {{ item }}.{{ host_domain}}{% endif %}"
     state: present
-  when: hostvars[item].ansible_default_ipv4.address is defined
+  when: hostvars[item].private_ipv4 is defined
   with_items: groups['all']
 
 - name: clean hosts file

--- a/roles/consul/README.rst
+++ b/roles/consul/README.rst
@@ -40,7 +40,7 @@ commonly used to least.
 .. data:: consul_advertise
 
    IP address Consul will advertise as available for other nodes to connect to.
-   Defaults to the value of ``ansible_default_ipv4.address``.
+   Defaults to the value of ``private_ipv4`` (from terraform inventory).
 
 .. data:: consul_is_server
 

--- a/roles/consul/defaults/main.yml
+++ b/roles/consul/defaults/main.yml
@@ -3,8 +3,8 @@ consul_is_server: yes
 consul_dc: dc1
 consul_dc_group: dc={{ consul_dc }}
 consul_servers_group: role=control
-consul_advertise: "{{ ansible_default_ipv4.address }}"
-consul_retry_join: "{% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group]) %}\"{{ hostvars[host].ansible_default_ipv4.address }}\"{% if not loop.last %}, {% endif %}{% endfor %}"
+consul_advertise: "{{ private_ipv4 }}"
+consul_retry_join: "{% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group]) %}\"{{ hostvars[host].private_ipv4 }}\"{% if not loop.last %}, {% endif %}{% endfor %}"
 consul_bootstrap_expect: "{{ groups[consul_servers_group] | intersect(groups[consul_dc_group]) | length }}"
 consul_disable_remote_exec: yes
 consul_ca_file: ca.cert

--- a/roles/consul/templates/nginx-consul.env.j2
+++ b/roles/consul/templates/nginx-consul.env.j2
@@ -1,4 +1,4 @@
 NGINX_KV=service/nginx/templates/consul
 NGINX_AUTH_TYPE=basic
 NGINX_AUTH_BASIC_KV=service/nginx/auth/users
-NGINX_PUBLIC_IP={{ ansible_default_ipv4.address }}
+NGINX_PUBLIC_IP={{ private_ipv4 }}

--- a/roles/dnsmasq/templates/10-consul
+++ b/roles/dnsmasq/templates/10-consul
@@ -13,8 +13,8 @@ server=8.8.4.4
 server=/{{ consul_dns_domain }}/127.0.0.1#8600
 
 {% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group]) %}
-{% if hostvars[host].ansible_default_ipv4.address != ansible_default_ipv4.address %}
-server=/{{ consul_dns_domain }}/{{ hostvars[host].ansible_default_ipv4.address }}#8600
+{% if hostvars[host].private_ipv4 != private_ipv4 %}
+server=/{{ consul_dns_domain }}/{{ hostvars[host].private_ipv4 }}#8600
 
 {% endif %}
 {% endfor %}

--- a/roles/marathon/templates/nginx-marathon.env.j2
+++ b/roles/marathon/templates/nginx-marathon.env.j2
@@ -1,7 +1,7 @@
 NGINX_KV=service/nginx/templates/marathon
 NGINX_AUTH_TYPE=basic
 NGINX_AUTH_BASIC_KV=service/nginx/auth/users
-NGINX_PUBLIC_IP={{ ansible_default_ipv4.address }}
+NGINX_PUBLIC_IP={{ private_ipv4 }}
 CONSUL_CONNECT=consul.service.consul:8500
 {% if do_consul_ssl|bool %}
 CONSUL_SSL=true

--- a/roles/mesos/templates/nginx-mesos-leader.env.j2
+++ b/roles/mesos/templates/nginx-mesos-leader.env.j2
@@ -1,7 +1,7 @@
 NGINX_KV=service/nginx/templates/mesos-leader
 NGINX_AUTH_TYPE=basic
 NGINX_AUTH_BASIC_KV=service/nginx/auth/users
-NGINX_PUBLIC_IP={{ ansible_default_ipv4.address }}
+NGINX_PUBLIC_IP={{ private_ipv4 }}
 CONSUL_CONNECT=consul.service.consul:8500
 {% if do_consul_ssl|bool %}
 CONSUL_SSL=true

--- a/roles/vault/templates/vault.config.j2
+++ b/roles/vault/templates/vault.config.j2
@@ -3,7 +3,7 @@ backend "consul" {
 	path = "vault"
 	scheme = "http"
 	token = "{{ consul_acl_master_token }}"
-	advertise_addr = "{{ ansible_default_ipv4.address }}"
+	advertise_addr = "{{ private_ipv4 }}"
 }
 
 listener "tcp" {

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -8,9 +8,12 @@
     consul_bootstrap_expect: 1
     mesos_cluster: vagrant
     mesos_mode: mixed
-    private_ipv4: "{{ ansible_default_ipv4.address }}"
-    public_ipv4: "{{ ansible_default_ipv4.address }}"
     provider: vagrant
+  pre_tasks:
+    - name: set vagrant ip addresses in inventory
+      set_fact:
+        private_ipv4: "{{ vagrant_private_ipv4 }}"
+        public_ipv4: "{{ vagrant_private_ipv4 }}"
   roles:
     - common
     - collectd

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -14,4 +14,4 @@ if [ ! -f /vagrant/security.yml ]; then
 fi
 
 hostname default
-ansible-playbook vagrant.yml -e @security.yml -i /vagrant/vagrant/vagrant-inventory
+ansible-playbook vagrant.yml -e @security.yml -e "vagrant_private_ipv4=$1" -i /vagrant/vagrant/vagrant-inventory


### PR DESCRIPTION
*Note: this should go after #612 and will depend on an updated CiscoCloud/microserivces-infrastructure vagrant image*

* replaces references of ansible_default_ipv4 with private_ipv4 variable
* depends on vagrant 1.7.3 for reliable networking
* obsoletes #512 
* fixes #503 