### PR TITLE
Fix/version packages

### DIFF
--- a/roles/chronos/defaults/main.yml
+++ b/roles/chronos/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+chronos_version: 2.3.4
+chronos_package: "chronos-{{ chronos_version }}"
+
 # right now there is an issue with chronos zookeeper connection with auth, so leave it blank for now
 chronos_zk_auth: "" 
 chronos_zk_dns: "zookeeper.service.{{ consul_dns_domain }}"

--- a/roles/chronos/tasks/main.yml
+++ b/roles/chronos/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: install chronos package
   sudo: yes
   yum:
-    name: chronos
+    name: "{{ chronos_package }}"
     state: present
   tags:
     - chronos

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+marathon_version: 0.9.0
+marathon_package: "marathon-{{ marathon_version }}"
+
 marathon_zk_auth: "{% if zk_marathon_user_secret is defined %}{{ zk_marathon_user }}:{{ zk_marathon_user_secret }}@{% endif %}"
 marathon_zk_dns: "zookeeper.service.{{ consul_dns_domain }}"
 marathon_zk_port: 2181

--- a/roles/marathon/tasks/main.yml
+++ b/roles/marathon/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: install marathon package
   sudo: yes
   yum:
-    name: marathon
+    name: "{{ marathon_package }}"
     state: present
   tags:
     - marathon

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+mesos_version: 0.22.1
+mesos_package: "mesos-{{ mesos_version }}"
+
 mesos_mode: follower 
 mesos_log_dir: /var/log/mesos
 mesos_work_dir: /var/run/mesos

--- a/roles/mesos/tasks/main.yml
+++ b/roles/mesos/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: install mesos package
   sudo: yes
   yum:
-    name: mesos
+    name: "{{ mesos_package }}"
     state: present
   tags:
     - mesos

--- a/roles/mesos/templates/mesos-master.conf.j2
+++ b/roles/mesos/templates/mesos-master.conf.j2
@@ -7,6 +7,6 @@ LoadPlugin python
         Host "{{ inventory_hostname }}.node.{{ consul_dns_domain }}"
         Port 15050
         Verbose false
-        Version "0.21.0"
+        Version "0.22.1"
     </Module>
 </Plugin>

--- a/roles/mesos/templates/mesos-slave.conf.j2
+++ b/roles/mesos/templates/mesos-slave.conf.j2
@@ -7,6 +7,6 @@ LoadPlugin python
         Host "{{ inventory_hostname }}.node.{{ consul_dns_domain }}"
         Port 5051
         Verbose false
-        Version "0.21.0"
+        Version "0.22.1"
     </Module>
 </Plugin>


### PR DESCRIPTION
Use explicit packages' versions for Chronos, Marathon and Mesos. Update the Mesos collectd plugin as well. Related to issue https://github.com/CiscoCloud/microservices-infrastructure/issues/614

The problem is that we deploy `latest` Mesos package with Ansible. This may result in various problems, for example, Marathon not tested enough to work correctly with the latest Mesos.