### PR TITLE
fix terraform.py to handle aws ebs_block_device

### DIFF
--- a/plugins/inventory/terraform.py
+++ b/plugins/inventory/terraform.py
@@ -111,18 +111,12 @@ def _parse_prefix(source, prefix, sep='.'):
 
 
 def parse_attr_list(source, prefix, sep='.'):
-    size_key = '%s%s#' % (prefix, sep)
-    try:
-        size = int(source[size_key])
-    except KeyError:
-        return []
-
-    attrs = [{} for _ in range(size)]
+    attrs = defaultdict(dict)
     for compkey, value in _parse_prefix(source, prefix, sep):
-        nth, key = compkey.split(sep, 1)
-        attrs[int(nth)][key] = value
+        idx, key = compkey.split(sep, 1)
+        attrs[idx][key] = value
 
-    return attrs
+    return attrs.values()
 
 
 def parse_dict(source, prefix, sep='.'):


### PR DESCRIPTION
On AWS, after provisioning GlusterFS in MI and refreshing your Terraform state, you end up with control node `ebs_block_device` definitions in your `tfstate` that look something like this:

```json
"ebs_block_device.3075786550.delete_on_termination": "false",
"ebs_block_device.3075786550.device_name": "xvdh",
"ebs_block_device.3075786550.encrypted": "false",
"ebs_block_device.3075786550.iops": "300",
"ebs_block_device.3075786550.snapshot_id": "",
"ebs_block_device.3075786550.volume_size": "100",
"ebs_block_device.3075786550.volume_type": "gp2",
```

Note that this doesn't use an `n` based index and is not compatible with `parse_attr_list` in `terraform.py`:

```shell
$ python plugins/inventory/terraform.py --list
Traceback (most recent call last):
  File "plugins/inventory/terraform.py", line 497, in <module>
    main()
  File "plugins/inventory/terraform.py", line 486, in main
    output = query_list(hosts)
  File "plugins/inventory/terraform.py", line 441, in query_list
    for name, attrs, hostgroups in hosts:
  File "plugins/inventory/terraform.py", line 67, in iterhosts
    yield parser(resource, module_name)
  File "plugins/inventory/terraform.py", line 83, in inner
    name, attrs, groups = func(*args, **kwargs)
  File "plugins/inventory/terraform.py", line 271, in aws_host
    'ebs_block_device': parse_attr_list(raw_attrs, 'ebs_block_device'),
  File "plugins/inventory/terraform.py", line 123, in parse_attr_list
    attrs[int(nth)][key] = value
IndexError: list index out of range
```

This change attempts to fix this