### PR TITLE
Set control_count and worker_count to 3 by default

### DIFF
--- a/terraform/aws.sample.tf
+++ b/terraform/aws.sample.tf
@@ -11,6 +11,6 @@ module "aws-dc" {
   worker_type = "t2.small"
   ssh_username = "centos"
   source_ami = "ami-96a818fe"
-  control_count = 2
+  control_count = 3
   worker_count = 3
 }

--- a/terraform/digitalocean.sample.tf
+++ b/terraform/digitalocean.sample.tf
@@ -12,6 +12,6 @@ module "do-hosts" {
   ssh_key = "${module.do-keypair.keypair_id}"
 
   region_name = "nyc3" # this must be a region with metadata support
-  control_count = 1
+  control_count = 3
   worker_count = 3
 }

--- a/terraform/gce.sample.tf
+++ b/terraform/gce.sample.tf
@@ -13,6 +13,6 @@ module "gce-dc" {
   long_name = "microservices-infrastructure"
   short_name = "mi"
   region = ""
-  control_count = 2
+  control_count = 3
   worker_count = 3
 }

--- a/terraform/openstack-floating.sample.tf
+++ b/terraform/openstack-floating.sample.tf
@@ -17,8 +17,8 @@ module "dc2-hosts-floating" {
         resource_flavor_name  = ""
         image_name = ""
         keypair_name = "${ module.dc2-keypair.keypair_name }"
-        control_count = 1
-        resource_count = 2
+        control_count = 3
+        resource_count = 3
 	floating_pool = ""
 	external_net_id = ""
 }

--- a/terraform/openstack.sample.tf
+++ b/terraform/openstack.sample.tf
@@ -18,7 +18,7 @@ module "dc2-hosts" {
   net_id = ""
   image_name = ""
   keypair_name = "${ module.dc2-keypair.keypair_name }"
-  control_count = 2
+  control_count = 3
   resource_count = 3
   security_groups = ""
   glusterfs_volume_size = 100

--- a/terraform/softlayer.sample.tf
+++ b/terraform/softlayer.sample.tf
@@ -12,6 +12,6 @@ module "softlayer-hosts" {
 
   region_name = "ams01"
   domain = "example.com"
-  control_count = 1
+  control_count = 3
   worker_count = 3
 }

--- a/terraform/vsphere.sample.tf
+++ b/terraform/vsphere.sample.tf
@@ -13,7 +13,7 @@ module "vsphere-dc" {
   host = ""
   pool = ""
   template = ""
-  control_count = 2
+  control_count = 3
   worker_count = 3
   ssh_user = ""
   ssh_key = ""


### PR DESCRIPTION
Standardize on 3 control servers and 3 worker nodes in the sample Terraform files