### PR TITLE
Correct variable name for enabling a user

### DIFF
--- a/docs/getting_started/ssh_users.rst
+++ b/docs/getting_started/ssh_users.rst
@@ -12,12 +12,12 @@ file will need to be passed to ``ansible-playbook`` with ``-e @users.yml``.
   ---
   users:
    - name: user1
-     enable: 1
+     enabled: 1
      pubkeys:
        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABA.....
 
   - name: user2
-      enable: 1
+      enabled: 1
       pubkeys: 
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAABA......
 


### PR DESCRIPTION
If a user copies the code from the documentation into a users.yml file, all users will be skipped:
`enable -> enabled`