### PR TITLE
Skip GlusterFS installation when no device is specified

### DIFF
--- a/roles/glusterfs/tasks/main.yml
+++ b/roles/glusterfs/tasks/main.yml
@@ -20,6 +20,7 @@
     - glusterfs
 
 - include: server.yml
-  when: glusterfs_mode == "server"
+  when: glusterfs_mode == "server" and glusterfs_brick_device != ""
 
 - include: client.yml
+  when: glusterfs_brick_device != ""

--- a/roles/glusterfs/tasks/server.yml
+++ b/roles/glusterfs/tasks/server.yml
@@ -5,7 +5,6 @@
     dev: "{{ glusterfs_brick_device }}"
     fstype: xfs
     opts: "-i size=512"
-  when: glusterfs_brick_device != ""
   tags:
     - glusterfs
     - disk
@@ -17,7 +16,6 @@
     name: "{{ glusterfs_brick_mount }}"
     recurse: yes
     mode: 0755
-  when: glusterfs_brick_device != ""
   tags:
     - glusterfs
     - disk


### PR DESCRIPTION
Installation would fail when no brick device is specified, which is the default case on anything but GCE, AWS, and OpenStack.

This fixes issue https://github.com/CiscoCloud/microservices-infrastructure/issues/636