### PR TITLE
Add support for private Docker registries

### DIFF
--- a/docs/security/security_setup.rst
+++ b/docs/security/security_setup.rst
@@ -77,6 +77,12 @@ Options
 
    Default: ``True``
 
+.. option:: --use-private-docker-hub
+
+   Provide (or skip, if False) credentials for a private Docker Hub account.
+
+   Default: ``False``
+
 .. option:: --consul
 
    Enable Consul security. This overrides all other Consul options.

--- a/roles/docker/README.rst
+++ b/roles/docker/README.rst
@@ -9,3 +9,16 @@ dependencies into a standardized unit for software development." Their site has
 `more on what Docker is <https://www.docker.com/whatisdocker>`_. We use it in
 microservices-infrastructure to ship units of work around the cluster, combined
 with :doc:`marathon`'s scheduling.
+
+Using a private Docker registry
+-------------------------------
+
+In addition to the open, official Docker registry at https://hub.docker.com,
+one can use a private in-house docker registry for storing and pulling images.
+Docker Hub also supports storing private images.
+
+One must configure credentials in order to use private repositories. This is
+done with the security-setup script, run it with the flag ``--use-private-docker-hub=true``.
+It will then ask you for username, password and e-mail address for the registry
+user. You can also specify a custom URL for an in-house Docker registry, or omit
+it, in which case it will default to the official registry, https://index.docker.io/v1/.

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -65,6 +65,23 @@
   tags:
     - docker
 
+- name: Assure docker config dir exists
+  sudo: yes
+  file:
+    path: /root/.docker
+    state: directory
+  tags:
+    - docker
+
+- name: setup private docker hub credentials
+  sudo: yes
+  when: do_private_docker_hub
+  template:
+    src: config.json.j2
+    dest: /root/.docker/config.json
+  tags:
+    - docker
+
 - name: enable docker
   sudo: yes
   service:

--- a/roles/docker/templates/config.json.j2
+++ b/roles/docker/templates/config.json.j2
@@ -1,0 +1,13 @@
+{
+    "auths": {
+        {% for registry in docker_registries %}
+        "{{ registry.docker_hub_url }}": {
+            "auth": "{{ registry.docker_hub_creds }}",
+            "email": "{{ registry.docker_hub_email }}"
+        }
+        {% if not loop.last %}
+            ,
+        {% endif %}
+        {% endfor %}
+    }
+}

--- a/security-setup
+++ b/security-setup
@@ -245,6 +245,17 @@ chronos_opts.add_argument(
     dest='do_chronos_iptables', default=True
 )
 
+# Docker hub security
+docker_hub_opts = parser.add_argument_group(
+    "Docker Hub options",
+    "optional; setup credentials for Docker Hub"
+)
+docker_hub_opts.add_argument(
+    '--use-private-docker-hub', type=ImplicitBool.parse_opt,
+    help='add credentials for a private Docker Hub',
+    dest='do_private_docker_hub', default=False
+)
+
 BASE = posixpath.abspath(posixpath.dirname(__file__)).replace("\\","/")
 SECURITY_FILE = posixpath.join(BASE, 'security.yml')
 
@@ -345,6 +356,24 @@ class Component(object):
             PASSWORDS[purpose] = password
 
         return re.escape(password)
+
+    def ask_string(self, prompt):
+        """
+        Ask the user for some string.
+        """
+        return raw_input(prompt)
+
+    def ask_boolean(self, prompt, default_value):
+        """
+        Ask the user for a boolean (Y/N)
+        """
+        result = raw_input(prompt).upper()
+        if result == 'Y':
+            return True
+        elif result == 'N':
+            return False
+        else:
+            return default_value
 
     def zk_digest(self, user, credential):
         """creates a zookeeper-compatible digest.
@@ -637,6 +666,45 @@ class Chronos(Component):
             else:
                 print('chronos http credentials already set')
 
+class DockerHub(Component):
+    def check(self):
+        return [self.docker_hub_auth]
+
+    def docker_hub_auth(self):
+        do_private_docker_hub = self.args.do_private_docker_hub
+        self.toggle_boolean('do_private_docker_hub', self.component_enabled(do_private_docker_hub), True)
+        "docker hub authentication"
+        if do_private_docker_hub:
+            with self.modify_security() as config:
+                if 'docker_registries' not in config:
+                    more_registries = True
+                    registries = []
+                    while more_registries:
+                        registry_config = {}
+                        creds = '{}:{}'.format(self.ask_string(
+                            prompt='Docker Hub username: '
+                        ), self.ask_pass(
+                            prompt='Docker Hub password: '
+                        ))
+
+                        registry_config['docker_hub_creds'] = base64.b64encode(creds)
+
+                        registry_config['docker_hub_email'] = self.ask_string(
+                            prompt='Docker Hub e-mail: ')
+
+                        default_url = 'https://index.docker.io/v1/'
+                        registry_config['docker_hub_url'] = self.ask_string(
+                            prompt='Docker Hub URL (default is {}): '.format(default_url))
+                        if registry_config['docker_hub_url'] == '':
+                            registry_config['docker_hub_url'] = default_url
+
+                        registries.append(registry_config)
+
+                        more_registries = self.ask_boolean("Are there more Docker registries? (y/N) ", False)
+                    config['docker_registries'] = registries
+                    print('set docker hub credentials')
+                else:
+                    print('docker hub credentials already set')
 
 class Zookeeper(Component):
     def check(self):


### PR DESCRIPTION
You can configure microservices-infrastructure to pull from private
docker registries (including hub.docker.com), this requires
credentials.

In order to set up credentials, run the security-setup script
with the option "--use-private-docker-hub=true" (defaults to false).
Even if you use a private hub, you will be able to pull public/official
images from the official, open docker hub.

The ansible task will insert the credentials into
/root/.docker/config.json
where the docker daemon will pick them up.

Also, some documentation was added.