### PR TITLE
Issue #500 - docker log rotation

### DIFF
--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -11,6 +11,12 @@
     name: collectd
     state: restarted
 
+- name: restart rsyslog
+  sudo: yes
+  service:
+    name: rsyslog
+    state: restarted
+
 - name: reload docker
   sudo: yes
   command: systemctl daemon-reload

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -30,12 +30,36 @@
     - docker
     - bootstrap
 
+- name: create rsyslog.d
+  sudo: yes
+  file:
+    dest: /etc/rsyslog.d
+    state: directory
+  tags:
+    - docker
+    - bootstrap
+
+- name: create docker entry for syslogd
+  sudo: yes
+  copy:
+    dest: /etc/rsyslog.d/10-docker.conf
+    content: |
+      # Docker logging
+      :syslogtag, isequal, "docker:"  /var/log/docker/docker.log
+      & ~
+  notify:
+    - restart rsyslog
+  tags:
+    - docker
+    - bootstrap
+
+
 - name: configure docker consul dns
   sudo: yes
   lineinfile:
     dest: /etc/sysconfig/docker
     regexp: ^other_arg=
-    line: other_arg='--dns {{ private_ipv4 }} --dns-search service.{{ consul_dns_domain }}'
+    line: other_arg='--dns {{ private_ipv4 }} --dns-search service.{{ consul_dns_domain }} --log-driver=syslog'
     state: present
     create: yes
   notify:

--- a/roles/logrotate/files/docker
+++ b/roles/logrotate/files/docker
@@ -1,9 +1,11 @@
-/var/lib/docker/containers/*/*.log {
+/var/log/docker/*.log {
         daily
         rotate 7
+        copytruncate
         missingok
         compress
         delaycompress
         notifempty
+        minsize 1
+        olddir archive
 }
-

--- a/roles/logrotate/tasks/main.yml
+++ b/roles/logrotate/tasks/main.yml
@@ -50,6 +50,15 @@
   tags:
     - logrotate
 
+- name: create docker archive
+  sudo: yes
+  file:
+    path: /var/log/docker/archive
+    mode: 0755
+    state: directory
+  tags:
+    - logrotate
+
 - name: configure zookeeper logrotate
   sudo: yes
   copy:


### PR DESCRIPTION
Force docker to use syslog log driver, and then use logrotate to rotate the syslog logs.

As per Issue https://github.com/CiscoCloud/microservices-infrastructure/issues/500.