### PR TITLE
Support for DNS providers

### DIFF
--- a/docs/getting_started/dnsimple.rst
+++ b/docs/getting_started/dnsimple.rst
@@ -1,0 +1,71 @@
+DNSimple
+=========
+
+Terraform can use DNSimple to provide DNS records for your cluster, independent of which
+provider you use to provision your servers. For configuration examples, look
+at the ``*.sample.tf`` files in the ``terraform/`` directory, which show how
+you can hook up a server provider's instances to DNSimple.
+
+DNSimple will provide these A-type records:
+
+- ``[short-name]-control-[nn].[domain]``
+- ``[short-name]-worker-[nnn].[domain]``
+- ``*.[short-name]-lb.[domain]``
+
+For example, with ``short-name=mi`` and ``domain=example.com``, 3 control
+nodes and 4 worker nodes, that will give us these DNS records:
+
+- ``mi-control-01.example.com``
+- ``mi-control-02.example.com``
+- ``mi-control-03.example.com``
+- ``mi-worker-001.example.com``
+- ``mi-worker-002.example.com``
+- ``mi-worker-003.example.com``
+- ``mi-worker-004.example.com``
+- ``mi-lb.example.com`` (pointing to worker 1)
+- ``mi-lb.example.com`` (pointing to worker 2)
+- ``mi-lb.example.com`` (pointing to worker 3)
+- ``mi-lb.example.com`` (pointing to worker 4)
+
+The control- and worker records are intented to be used to access
+the nodes directly, e.g. via your browser. You can then reach the
+Marathon control panel at `http://mi-control-01.example.com:8080/
+<http://mi-control-01.example.com:8080/>`_.
+
+The lb records are intended to reach your load balancers that run
+on every worker node. That makes it easy to access your load-balanced
+applications from the browser, for example `http://myapp.mi-lb.example.com/
+<http://myapp.mi-lb.example.com/>`_. For this to work, you will have to
+configure ansible to setup the correct domain for haproxy as well. Look
+at ``terraform.sample.yml`` for hints.
+
+Beware that in a dynamic environment, where worker nodes are being brought
+up and taken down frequently, it's not a good idea to point traffic direcly
+to the LB URLs - because of DNS caching. If a DNS record changes, it can
+take a while for the change to propagate to all the clients. Your best bet
+for frontend applications is to route traffic to them via user-facing
+load balancers that seldom change IP addresses or are shut down/restarted.
+
+DNSimple Username/Token
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The easiest way to configure credentials for DNSimple is by setting
+environment variables:
+
+.. envvar:: DNSIMPLE_EMAIL
+
+   Your e-mail address for the DNSimple account
+
+.. envvar:: DNSIMPLE_TOKEN
+
+   The DNSimple token (found in the DNSimple admin panel)
+
+Alternatively, you can set up the DNSimple provider credentials in your .tf
+file:
+
+.. code-block:: shell
+  provider "dnsimple" {
+    token = "your dnsimple token"
+    email = "your e-mail address for the dnsimple account"
+  }
+

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -31,6 +31,20 @@ platforms:
    vsphere.rst
    softlayer.rst
 
+Setting up DNS
+--------------
+
+Terraform lets you configure DNS for your instances. The DNS provider is
+loosely coupled from the server provider, so you could for example use
+the dnsimple provider for either OpenStack or AWS hosts.
+
+These are the supported DNS providers:
+
+.. toctree::
+   :maxdepth: 1
+
+   dnsimple.rst
+
 Setting up Authentication and Authorization
 -------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ distributed services.
 Features
 --------
 
-* `Terraform <https://terraform.io/>`_ deployment to multiple cloud providers
+* `Terraform <https://terraform.io/>`_ deployment to multiple cloud and DNS providers
 * `etcd <https://github.com/coreos/etcd>`_ distributed key-value store for Calico
 * `Calico <http://www.projectcalico.org>`_ a new kind of virtual network
 * `Mesos <https://mesos.apache.org/>`_ cluster manager for efficient resource

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -59,6 +59,12 @@
   vars:
     consul_dns_domain: consul
     mesos_mode: follower
+
+    # Set this to whatever domain you want to reach haproxy from; it should be
+    # in this format: [short-name]-lb.[domain], where [short-name] and [domain]
+    # are the same as configured in terraform.
+    # In this example, short-name is "mi" and domain is "example.com":
+    haproxy_domain: mi-lb.example.com
   roles:
     - calico
     - mesos

--- a/terraform/aws.sample.tf
+++ b/terraform/aws.sample.tf
@@ -14,3 +14,14 @@ module "aws-dc" {
   control_count = 3
   worker_count = 3
 }
+
+# Example setup for DNS with dnsimple;
+# module "dnsimple-dns" {
+#   source = "./terraform/dnsimple/dns"
+#   short_name = "mi"
+#   control_count = 3
+#   worker_count = 3
+#   domain = "example.com"
+#   control_ips = "${module.aws-dc.control_ips}"
+#   worker_ips = "${module.aws-dc.worker_ips}"
+# }

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -237,3 +237,11 @@ resource "aws_key_pair" "deployer" {
   key_name = "key-${var.short_name}"
   public_key = "${file(var.ssh_key)}"
 }
+
+output "control_ips" {
+  value = "${join(\",\", aws_instance.mi-control-nodes.*.public_ip)}"
+}
+
+output "worker_ips" {
+  value = "${join(\",\", aws_instance.mi-worker-nodes.*.public_ip)}"
+}

--- a/terraform/digitalocean.sample.tf
+++ b/terraform/digitalocean.sample.tf
@@ -15,3 +15,14 @@ module "do-hosts" {
   control_count = 3
   worker_count = 3
 }
+
+# Example setup for DNS with dnsimple;
+# module "dnsimple-dns" {
+#   source = "./terraform/dnsimple/dns"
+#   short_name = "mi"
+#   control_count = 3
+#   worker_count = 3
+#   domain = "example.com"
+#   control_ips = "${module.do-hosts.control_ips}"
+#   worker_ips = "${module.do-hosts.worker_ips}"
+# }

--- a/terraform/digitalocean/hosts/main.tf
+++ b/terraform/digitalocean/hosts/main.tf
@@ -29,3 +29,11 @@ resource "digitalocean_droplet" "worker" {
   ssh_keys = ["${var.ssh_key}"]
   user_data = "{\"role\":\"worker\",\"dc\":\"${var.datacenter}\"}"
 }
+
+output "control_ips" {
+  value = "${join(\",\", digitalocean_droplet.control.*.ipv4_address)}"
+}
+
+output "worker_ips" {
+  value = "${join(\",\", digitalocean_droplet.worker.*.ipv4_address)}"
+}

--- a/terraform/dnsimple/dns/main.tf
+++ b/terraform/dnsimple/dns/main.tf
@@ -26,7 +26,7 @@ resource "dnsimple_record" "dns-worker" {
 resource "dnsimple_record" "dns-worker-haproxy" {
   count = "${var.worker_count}"
   domain = "${var.domain}"
-  name = "*.service.${var.short_name}"
+  name = "*.${var.short_name}-lb"
   value = "${element(split(\",\", var.worker_ips), count.index)}"
   type = "A"
   ttl = 60

--- a/terraform/dnsimple/dns/main.tf
+++ b/terraform/dnsimple/dns/main.tf
@@ -1,0 +1,33 @@
+variable control_ips {}
+variable worker_ips {}
+variable control_count {}
+variable worker_count {}
+variable domain {}
+variable short_name {}
+
+resource "dnsimple_record" "dns-control" {
+  count = "${var.control_count}"
+  domain = "${var.domain}"
+  value = "${element(split(\",\", var.control_ips), count.index)}"
+  name = "${var.short_name}-control-${format("%02d", count.index+1)}"
+  type = "A"
+  ttl = 60
+}
+
+resource "dnsimple_record" "dns-worker" {
+  count = "${var.worker_count}"
+  domain = "${var.domain}"
+  name = "${var.short_name}-worker-${format("%03d", count.index+1)}"
+  value = "${element(split(\",\", var.worker_ips), count.index)}"
+  type = "A"
+  ttl = 60
+}
+
+resource "dnsimple_record" "dns-worker-haproxy" {
+  count = "${var.worker_count}"
+  domain = "${var.domain}"
+  name = "*.service.${var.short_name}"
+  value = "${element(split(\",\", var.worker_ips), count.index)}"
+  type = "A"
+  ttl = 60
+}

--- a/terraform/gce.sample.tf
+++ b/terraform/gce.sample.tf
@@ -16,3 +16,14 @@ module "gce-dc" {
   control_count = 3
   worker_count = 3
 }
+
+# Example setup for DNS with dnsimple;
+# module "dnsimple-dns" {
+#   source = "./terraform/dnsimple/dns"
+#   short_name = "mi"
+#   control_count = 3
+#   worker_count = 3
+#   domain = "example.com"
+#   control_ips = "${module.gce-dc.control_ips}"
+#   worker_ips = "${module.gce-dc.worker_ips}"
+# }

--- a/terraform/gce/gce.tf
+++ b/terraform/gce/gce.tf
@@ -130,3 +130,11 @@ resource "google_compute_instance" "mi-worker-nodes" {
 
   count = "${var.worker_count}"
 }
+
+output "control_ips" {
+  value = "${join(\",\", google_compute_instance.mi-control-nodes.*.access_config.nat_ip)}"
+}
+
+output "worker_ips" {
+  value = "${join(\",\", google_compute_instance.mi-worker-nodes.*.access_config.nat_ip)}"
+}

--- a/terraform/gce/gce.tf
+++ b/terraform/gce/gce.tf
@@ -132,9 +132,9 @@ resource "google_compute_instance" "mi-worker-nodes" {
 }
 
 output "control_ips" {
-  value = "${join(\",\", google_compute_instance.mi-control-nodes.*.access_config.nat_ip)}"
+  value = "${join(\",\", google_compute_instance.mi-control-nodes.*.network_interface.0.access_config.0.nat_ip)}"
 }
 
 output "worker_ips" {
-  value = "${join(\",\", google_compute_instance.mi-worker-nodes.*.access_config.nat_ip)}"
+  value = "${join(\",\", google_compute_instance.mi-worker-nodes.*.network_interface.0.access_config.0.nat_ip)}"
 }

--- a/terraform/openstack-floating.sample.tf
+++ b/terraform/openstack-floating.sample.tf
@@ -22,3 +22,14 @@ module "dc2-hosts-floating" {
 	floating_pool = ""
 	external_net_id = ""
 }
+
+# Example setup for DNS with dnsimple;
+# module "dnsimple-dns" {
+#   source = "./terraform/dnsimple/dns"
+#   short_name = "mi"
+#   control_count = 3
+#   worker_count = 3
+#   domain = "example.com"
+#   control_ips = "${module.dc2-hosts.control_ips}"
+#   worker_ips = "${module.dc2-hosts.worker_ips}"
+# }

--- a/terraform/openstack.sample.tf
+++ b/terraform/openstack.sample.tf
@@ -23,3 +23,14 @@ module "dc2-hosts" {
   security_groups = ""
   glusterfs_volume_size = 100
 }
+
+# Example setup for DNS with dnsimple;
+# module "dnsimple-dns" {
+#   source = "./terraform/dnsimple/dns"
+#   short_name = "mi"
+#   control_count = 3
+#   worker_count = 3
+#   domain = "example.com"
+#   control_ips = "${module.dc2-hosts.control_ips}"
+#   worker_ips = "${module.dc2-hosts.worker_ips}"
+# }

--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -91,3 +91,11 @@ resource "openstack_networking_router_interface_v2" "ms-router-interface" {
   router_id = "${ openstack_networking_router_v2.ms-router.id }"
   subnet_id = "${ openstack_networking_subnet_v2.ms-subnet.id }"
 }
+
+output "control_ips" {
+  value = "${join(\",\", openstack_compute_instance_v2.control.*.access_ip_v4)}"
+}
+
+output "worker_ips" {
+  value = "${join(\",\", openstack_compute_instance_v2.resource.*.access_ip_v4)}"
+}

--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -64,3 +64,11 @@ resource "openstack_compute_instance_v2" "resource" {
   }
   count = "${ var.resource_count }"
 }
+
+output "control_ips" {
+  value = "${join(\",\", openstack_compute_instance_v2.control.*.access_ip_v4)}"
+}
+
+output "worker_ips" {
+  value = "${join(\",\", openstack_compute_instance_v2.resource.*.access_ip_v4)}"
+}

--- a/terraform/softlayer.sample.tf
+++ b/terraform/softlayer.sample.tf
@@ -15,3 +15,14 @@ module "softlayer-hosts" {
   control_count = 3
   worker_count = 3
 }
+
+# Example setup for DNS with dnsimple;
+# module "dnsimple-dns" {
+#   source = "./terraform/dnsimple/dns"
+#   short_name = "mi"
+#   control_count = 3
+#   worker_count = 3
+#   domain = "example.com"
+#   control_ips = "${module.softlayer-hosts.control_ips}"
+#   worker_ips = "${module.softlayer-hosts.worker_ips}"
+# }

--- a/terraform/softlayer/hosts/main.tf
+++ b/terraform/softlayer/hosts/main.tf
@@ -34,3 +34,11 @@ resource "softlayer_virtualserver" "worker" {
   ssh_keys = ["${var.ssh_key}"]
   user_data = "{\"role\":\"worker\",\"dc\":\"${var.datacenter}\"}"
 }
+
+output "control_ips" {
+  value = "${join(\",\", softlayer_virtualserver.control.*.ipv4_address)}"
+}
+
+output "worker_ips" {
+  value = "${join(\",\", softlayer_virtualserver.worker.*.ipv4_address)}"
+}

--- a/terraform/vsphere.sample.tf
+++ b/terraform/vsphere.sample.tf
@@ -19,3 +19,14 @@ module "vsphere-dc" {
   ssh_key = ""
   consul_dc = ""
 }
+
+# Example setup for DNS with dnsimple;
+# module "dnsimple-dns" {
+#   source = "./terraform/dnsimple/dns"
+#   short_name = "mi"
+#   control_count = 3
+#   worker_count = 3
+#   domain = "example.com"
+#   control_ips = "${module.vsphere-dc.control_ips}"
+#   worker_ips = "${module.vsphere-dc.worker_ips}"
+# }

--- a/terraform/vsphere/main.tf
+++ b/terraform/vsphere/main.tf
@@ -75,3 +75,11 @@ resource "vsphere_virtual_machine" "mi-worker-nodes" {
 
   count = "${var.worker_count}"
 }
+
+output "control_ips" {
+  value = "${join(\",\", vsphere_virtual_machine.mi-control-nodes.*.network_interface.ip_address)}"
+}
+
+output "worker_ips" {
+  value = "${join(\",\", vsphere_virtual_machine.mi-worker-nodes.*.network_interface.ip_address)}"
+}


### PR DESCRIPTION
This means you will get actual DNS records for your mi cluster, which makes it much easier to work with.

I have already tested this with SoftLayer and dnsimple. It would be great if somebody could test it with the other clouds as well!
