### PR TITLE
Fix/update nginx

### DIFF
--- a/roles/chronos/defaults/main.yml
+++ b/roles/chronos/defaults/main.yml
@@ -22,9 +22,3 @@ chronos_port: 14400
 chronos_proxy_port: 4400
 
 # framework authentication
-
-# register service with consul
-consul_bin: /bin/consul
-consul_dir: /etc/consul
-consul_nginx_image: ciscocloud/nginx-consul
-consul_nginx_image_tag: 1.1

--- a/roles/chronos/templates/nginx-chronos.service.j2
+++ b/roles/chronos/templates/nginx-chronos.service.j2
@@ -3,7 +3,7 @@ Description=nginx-marathon
 After=docker.service
 After=consul.service
 Requires=docker.service
-Requires=consul.service
+Wants=consul.service
 
 [Service]
 Restart=on-failure

--- a/roles/consul/defaults/main.yml
+++ b/roles/consul/defaults/main.yml
@@ -10,8 +10,6 @@ consul_disable_remote_exec: yes
 consul_ca_file: ca.cert
 consul_cert_file: consul.cert
 consul_key_file: consul.key
-consul_nginx_image: ciscocloud/nginx-consul
-consul_nginx_image_tag: 1.1
 consul_acl_master_token: "89ff9d38-534a-41aa-a3a6-e4985bcd11c0"
 consul_acl_datacenter: "{{ consul_dc }}"
 consul_acl_default_policy: "allow"

--- a/roles/consul/templates/nginx-consul.service.j2
+++ b/roles/consul/templates/nginx-consul.service.j2
@@ -3,7 +3,7 @@ Description=nginx-consul
 After=docker.service
 After=consul.service
 Requires=docker.service
-Requires=consul.service
+Wants=consul.service
 
 [Service]
 Restart=on-failure

--- a/roles/handlers/defaults/main.yml
+++ b/roles/handlers/defaults/main.yml
@@ -1,0 +1,4 @@
+consul_nginx_image: ciscocloud/nginx-consul
+consul_nginx_image_tag: 1.1
+consul_bin: /bin/consul
+consul_dir: /etc/consul

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -25,12 +25,6 @@ marathon_proxy_port: 8080
 marathon_principal: marathon
 marathon_secret: ""
 
-# register service with consul
-consul_bin: /bin/consul
-consul_dir: /etc/consul
-consul_nginx_image: ciscocloud/nginx-consul
-consul_nginx_image_tag: 1.1
-
 # jobs
 mesos_consul_image: ciscocloud/mesos-consul
 mesos_consul_image_tag: v0.2

--- a/roles/marathon/templates/nginx-marathon.service.j2
+++ b/roles/marathon/templates/nginx-marathon.service.j2
@@ -3,7 +3,7 @@ Description=nginx-marathon
 After=docker.service
 After=consul.service
 Requires=docker.service
-Requires=consul.service
+Wants=consul.service
 
 [Service]
 Restart=on-failure

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -32,10 +32,3 @@ mesos_authenticate_frameworks: "{{ mesos_credentials|length > 0 }}"
 mesos_authenticate_followers: "{{ mesos_follower_secret != '' }}"
 mesos_follower_principal: follower
 mesos_follower_secret: ""
-
-# register serivce with consul
-consul_bin: /bin/consul
-consul_dir: /etc/consul
-consul_nginx_image: ciscocloud/nginx-consul
-consul_nginx_image_tag: 1.1
-

--- a/roles/mesos/templates/nginx-mesos-leader.service.j2
+++ b/roles/mesos/templates/nginx-mesos-leader.service.j2
@@ -3,7 +3,7 @@ Description=nginx-mesos-leader
 After=docker.service
 After=consul.service
 Requires=docker.service
-Requires=consul.service
+Wants=consul.service
 
 [Service]
 Restart=on-failure

--- a/roles/vault/files/vault.service
+++ b/roles/vault/files/vault.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=vault
 After=consul.service
-Requires=consul.service
+Wants=consul.service
 
 [Service]
 Restart=on-failure


### PR DESCRIPTION
* Consolidate some Consul variables that are common between roles into the `handlers` role. 
* Change vault and the nginx proxy services to use `Wants: consul.service` instead of `Requires: consul.service`. The processes can continue running without a consul server. They will just reconnect when the server becomes available.