### PR TITLE
Add Docker credentials to /etc

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -82,6 +82,15 @@
   tags:
     - docker
 
+- name: add docker registry credentials to /etc/
+  sudo: yes
+  when: do_private_docker_registry
+  command: tar cvzf /etc/docker.tar.gz .docker
+  args:
+    chdir: /root
+  tags:
+    - docker
+
 - name: enable docker
   sudo: yes
   service:


### PR DESCRIPTION
This is a follow up to #644. Pulling from a private docker registry worked fine on the command line, but from Marathon it didn't work, I guess because of Mesos' sandbox that didn't give Docker access to /root/.docker/config.json. This patch follows the [official Marathon guide](https://mesosphere.github.io/marathon/docs/native-docker-private-registry.html) on how to use private registries.

@ryane I'm sorry I didn't test #644 properly on Marathon with the newest Docker version! At least now it works in Marathon too :wink: