### PR TITLE
Consistent naming of worker nodes.

### DIFF
--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -41,7 +41,7 @@ resource "openstack_compute_instance_v2" "control" {
 
 resource "openstack_compute_instance_v2" "resource" {
   floating_ip = "${ element(openstack_compute_floatingip_v2.ms-resource-floatip.*.address, count.index) }"
-  name                  = "${ var.short_name}-worker-${format("%02d", count.index+1) }"
+  name                  = "${ var.short_name}-worker-${format("%03d", count.index+1) }"
   key_pair              = "${ var.keypair_name }"
   image_name            = "${ var.image_name }"
   flavor_name           = "${ var.resource_flavor_name }"

--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -51,7 +51,7 @@ resource "openstack_compute_instance_v2" "control" {
 }
 
 resource "openstack_compute_instance_v2" "resource" {
-  name = "${ var.short_name}-worker-${format("%02d", count.index+1) }"
+  name = "${ var.short_name}-worker-${format("%03d", count.index+1) }"
   key_pair = "${ var.keypair_name }"
   image_name = "${ var.image_name }"
   flavor_name = "${ var.resource_flavor_name }"

--- a/terraform/vsphere/main.tf
+++ b/terraform/vsphere/main.tf
@@ -47,7 +47,7 @@ resource "vsphere_virtual_machine" "mi-control-nodes" {
 }
 
 resource "vsphere_virtual_machine" "mi-worker-nodes" {
-  name = "${var.short_name}-worker-${format("%02d", count.index+1)}"
+  name = "${var.short_name}-worker-${format("%03d", count.index+1)}"
   image = "${var.template}"
 
   datacenter = "${var.datacenter}"


### PR DESCRIPTION
The worker nodes name are inconsistent. For some providers it is
short_name-control-xx while others are short_name-control-xxx.
This commit sets the worker nodes name to short_name-control-xxx for all providers.