### PR TITLE
Fix collectd->logstash input types

### DIFF
--- a/roles/logstash/templates/logstash-service.j2
+++ b/roles/logstash/templates/logstash-service.j2
@@ -27,6 +27,7 @@ ExecStart=/usr/bin/docker run \
     --volume=/var/lib/docker/containers:/logs/docker:ro \
     --volume=/var/log/mesos:/logs/mesos:ro \
     --volume=/var/log/zookeeper:/logs/zookeeper:ro \
+    --volume=/usr/share/collectd:/collectd:ro \
     {{ logstash_image }}:{{ logstash_image_tag }}
 
 ExecStop=/bin/bash -c " \

--- a/roles/logstash/templates/logstash.conf.j2
+++ b/roles/logstash/templates/logstash.conf.j2
@@ -19,7 +19,9 @@ input {
   udp {
     port => 25826
     type => collectd
-    codec => collectd
+    codec => collectd {
+      typesdb => ["/collectd/types.db", "/collectd/plugins/dockerplugin.db"]
+    }
   }
   udp {
     port => 8125


### PR DESCRIPTION
Problem: Logstash didn't understand values coming from collectd:

:message=>"Invalid value for type=\"cpu.usage\", key=nil, index=3",
:level=>:error

This was because logstash's collectd input wasn't configured with
types.db for Docker stats.
This commit mounts the collectd plugin volume into the logstash
container, and configures logstash so it reads types.db for the
docker-collectd plugin.