### PR TITLE
Fix wrong ordering of alias and hostname when adding entries to /etc/…

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -13,8 +13,8 @@
   sudo: yes
   lineinfile:
     dest: /etc/hosts
-    regexp: "^{{ hostvars[item].private_ipv4 }} {{ item }}{% if use_host_domain %} {{ item }}.{{ host_domain }}{% endif %}$"
-    line: "{{ hostvars[item].private_ipv4 }} {{ item }}{% if use_host_domain %} {{ item }}.{{ host_domain}}{% endif %}"
+    regexp: "^{{ hostvars[item].private_ipv4 }} {{ item }}{% if use_host_domain %}.{{ host_domain }}{% endif %} {{ item }}$"
+    line: "{{ hostvars[item].private_ipv4 }} {{ item }}{% if use_host_domain %}.{{ host_domain}}{% endif %} {{ item }}"
     state: present
   when: hostvars[item].private_ipv4 is defined
   with_items: groups['all']


### PR DESCRIPTION
…hosts.

Entries in /etc/hosts should be in the form: IPAdress Hostname Alias.
Looks like they were in the form:  IPAdress Alias Hostname.