### PR TITLE
Comment out consul_acl_datacenter by default

### DIFF
--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -23,7 +23,7 @@
     # consul_acl_datacenter should be set to the datacenter you want to control
     # Consul ACLs. If you only have one datacenter, set it to that or remove
     # this variable.
-    consul_acl_datacenter: your_primary_datacenter
+    # consul_acl_datacenter: your_primary_datacenter
 
     # consul_dns_domain is repeated across these plays so that all the
     # components know what information to use for this values to help with


### PR DESCRIPTION
This is a common gotcha that bites people, and it's a bit difficult to debug.
Let's disable it by default, since most people will probably start with a single DC anyways.

See #648