### PR TITLE
docker: optionally skip upstream yum repo usage

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+do_upstream_docker_repository: true

--- a/roles/docker/tasks/centos.yml
+++ b/roles/docker/tasks/centos.yml
@@ -1,0 +1,25 @@
+---
+- name: centos | install docker packages
+  sudo: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - docker
+    - docker-selinux
+  tags:
+    - docker
+    - bootstrap
+
+- name: centos | configure docker consul dns
+  sudo: yes
+  lineinfile:
+    dest: /etc/sysconfig/docker
+    regexp: ^OPTIONS=
+    line: OPTIONS='--selinux-enabled --dns {{ private_ipv4 }} --dns-search service.{{ consul_dns_domain }} --log-driver=syslog'
+    state: present
+    create: yes
+  notify:
+    - restart docker
+  tags:
+    - docker

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -9,26 +9,11 @@
     - docker
     - bootstrap
 
-- name: install docker repo
-  sudo: yes
-  copy:
-    src: docker.repo
-    dest: /etc/yum.repos.d/docker.repo
-  tags:
-    - docker
-    - bootstrap
+- include: upstream.yml
+  when: do_upstream_docker_repository|bool
 
-- name: install docker packages
-  sudo: yes
-  yum:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - docker-engine-1.7.0
-    - docker-selinux
-  tags:
-    - docker
-    - bootstrap
+- include: centos.yml
+  when: not do_upstream_docker_repository|bool
 
 - name: create rsyslog.d
   sudo: yes
@@ -52,42 +37,6 @@
   tags:
     - docker
     - bootstrap
-
-
-- name: configure docker consul dns
-  sudo: yes
-  lineinfile:
-    dest: /etc/sysconfig/docker
-    regexp: ^other_arg=
-    line: other_arg='--dns {{ private_ipv4 }} --dns-search service.{{ consul_dns_domain }} --log-driver=syslog'
-    state: present
-    create: yes
-  notify:
-    - restart docker
-  tags:
-    - docker
-
-- name: create docker.system.d
-  sudo: yes
-  file:
-    dest: /etc/systemd/system/docker.service.d
-    state: directory
-  tags:
-    - docker
-
-- name: create local docker service override
-  sudo: yes
-  copy:
-    dest: /etc/systemd/system/docker.service.d/local.conf
-    content: |
-      [Service]
-      EnvironmentFile=-/etc/sysconfig/docker
-      ExecStart=
-      ExecStart=/usr/bin/docker -d -H fd:// $other_arg
-  notify:
-    - reload docker
-  tags:
-    - docker
 
 - name: ensure docker config dir exists
   sudo: yes

--- a/roles/docker/tasks/upstream.yml
+++ b/roles/docker/tasks/upstream.yml
@@ -1,0 +1,56 @@
+---
+- name: upstream | install docker repo
+  sudo: yes
+  copy:
+    src: docker.repo
+    dest: /etc/yum.repos.d/docker.repo
+  tags:
+    - docker
+    - bootstrap
+
+- name: upstream | install docker packages
+  sudo: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - docker-engine-1.7.0
+    - docker-selinux
+  tags:
+    - docker
+    - bootstrap
+
+- name: upstream | configure docker consul dns
+  sudo: yes
+  lineinfile:
+    dest: /etc/sysconfig/docker
+    regexp: ^other_arg=
+    line: other_arg='--dns {{ private_ipv4 }} --dns-search service.{{ consul_dns_domain }} --log-driver=syslog'
+    state: present
+    create: yes
+  notify:
+    - restart docker
+  tags:
+    - docker
+
+- name: upstream | create docker.system.d
+  sudo: yes
+  file:
+    dest: /etc/systemd/system/docker.service.d
+    state: directory
+  tags:
+    - docker
+
+- name: upstream | create local docker service override
+  sudo: yes
+  copy:
+    dest: /etc/systemd/system/docker.service.d/local.conf
+    content: |
+      [Service]
+      EnvironmentFile=-/etc/sysconfig/docker
+      ExecStart=
+      ExecStart=/usr/bin/docker -d -H fd:// $other_arg
+  notify:
+    - reload docker
+  tags:
+    - docker


### PR DESCRIPTION
This change introduces a conditional flag do_upstream_docker_repository
defaulting to true when using the docker role.

If set to true, the upstream yum repository will be used to install docker
packages and any related configuration will be performed (old behaviour).

If set to false, upstream repository will not be used, and the OS
provided docker package will be used.

Resolves: #688