### PR TITLE
Feature/openstack server groups

### DIFF
--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -4,6 +4,7 @@ variable tenant_id { }
 variable tenant_name { }
 variable control_flavor_name { }
 variable resource_flavor_name { }
+variable glusterfs_volume_size { default = "100" } # size is in gigabytes
 variable keypair_name { }
 variable image_name { }
 variable control_count {}
@@ -23,6 +24,16 @@ provider "openstack" {
   tenant_name	= "${ var.tenant_name }"
 }
 
+resource "openstack_blockstorage_volume_v1" "k8s-glusterfs" {
+  name = "${ var.short_name }-master-glusterfs-${format("%02d", count.index+1) }"
+  description = "${ var.short_name }-master-glusterfs-${format("%02d", count.index+1) }"
+  size = "${ var.glusterfs_volume_size }"
+  metadata = {
+    usage = "container-volumes"
+  }
+  count = "${ var.master_count }"
+}
+
 resource "openstack_compute_instance_v2" "control" {
   floating_ip = "${ element(openstack_compute_floatingip_v2.ms-control-floatip.*.address, count.index) }"
   name                  = "${ var.short_name}-control-${format("%02d", count.index+1) }"
@@ -31,6 +42,10 @@ resource "openstack_compute_instance_v2" "control" {
   flavor_name           = "${ var.control_flavor_name }"
   security_groups       = [ "${ var.security_groups }" ]
   network               = { uuid = "${ openstack_networking_network_v2.ms-network.id }" }
+  volume = {
+    volume_id = "${element(openstack_blockstorage_volume_v1.k8s-glusterfs.*.id, count.index)}"
+    device = "/dev/vdb"
+  }
   metadata              = {
                             dc = "${var.datacenter}"
                             role = "control"

--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -48,7 +48,7 @@ resource "openstack_compute_instance_v2" "control" {
   image_name            = "${ var.image_name }"
   flavor_name           = "${ var.control_flavor_name }"
   security_groups       = [ "${ var.security_groups }" ]
-  scheduler_hints = { group = "${ openstack_compute_servergroup_v2.control-sg.id }"
+  scheduler_hints = { group = "${ openstack_compute_servergroup_v2.control-sg.id }" }
   network               = { uuid = "${ openstack_networking_network_v2.ms-network.id }" }
   volume = {
     volume_id = "${element(openstack_blockstorage_volume_v1.k8s-glusterfs.*.id, count.index)}"

--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -26,14 +26,14 @@ provider "openstack" {
   tenant_name	= "${ var.tenant_name }"
 }
 
-resource "openstack_blockstorage_volume_v1" "k8s-glusterfs" {
-  name = "${ var.short_name }-master-glusterfs-${format("%02d", count.index+1) }"
-  description = "${ var.short_name }-master-glusterfs-${format("%02d", count.index+1) }"
+resource "openstack_blockstorage_volume_v1" "mi-control-glusterfs" {
+  name = "${ var.short_name }-control-glusterfs-${format("%02d", count.index+1) }"
+  description = "${ var.short_name }-control-glusterfs-${format("%02d", count.index+1) }"
   size = "${ var.glusterfs_volume_size }"
   metadata = {
     usage = "container-volumes"
   }
-  count = "${ var.master_count }"
+  count = "${ var.control_count }"
 }
 
 resource "openstack_compute_servergroup_v2" "control-sg" {
@@ -51,7 +51,7 @@ resource "openstack_compute_instance_v2" "control" {
   scheduler_hints = { group = "${ openstack_compute_servergroup_v2.control-sg.id }" }
   network               = { uuid = "${ openstack_networking_network_v2.ms-network.id }" }
   volume = {
-    volume_id = "${element(openstack_blockstorage_volume_v1.k8s-glusterfs.*.id, count.index)}"
+    volume_id = "${element(openstack_blockstorage_volume_v1.mi-control-glusterfs.*.id, count.index)}"
     device = "/dev/vdb"
   }
   metadata              = {

--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -44,7 +44,7 @@ resource "openstack_compute_instance_v2" "control" {
   image_name = "${ var.image_name }"
   flavor_name = "${ var.control_flavor_name }"
   security_groups = [ "${ var.security_groups }" ]
-  scheduler_hints = { group = "${ openstack_compute_servergroup_v2.control-sg.id }"
+  scheduler_hints = { group = "${ openstack_compute_servergroup_v2.control-sg.id }" }
   network = { uuid  = "${ var.net_id }" }
   volume = {
     volume_id = "${element(openstack_blockstorage_volume_v1.mi-control-glusterfs.*.id, count.index)}"


### PR DESCRIPTION
Adds Terraform configuration to support server groups in Openstack as requested in issue #681  
Allows defining either Anti-affinity or affinity as the default group policy and passes the appropriate scheduler hint to nova during instance creation.
Also adds the Gluster volume creation to the floating IP template.