### PR TITLE
mi-deploy: wait for hosts to be ready before SSH

### DIFF
--- a/mi-deploy/mi-deploy.go
+++ b/mi-deploy/mi-deploy.go
@@ -109,7 +109,7 @@ func ExecuteWithOutput(cmd *exec.Cmd) (outStr string, err error) {
 	}
 	outScanner := bufio.NewScanner(outReader)
 	for outScanner.Scan() {
-		outStr += outScanner.Text()
+		outStr += outScanner.Text() + "\n"
 		if log.GetLevel() == log.DebugLevel {
 			fmt.Println(outScanner.Text())
 		}


### PR DESCRIPTION
Will cause mi-deploy to be successful on the first run more often. 
Fixes #711, see #709.