### PR TITLE
Update nginx-consul container to 1.2

### DIFF
--- a/roles/handlers/defaults/main.yml
+++ b/roles/handlers/defaults/main.yml
@@ -1,4 +1,4 @@
 consul_nginx_image: ciscocloud/nginx-consul
-consul_nginx_image_tag: 1.1
+consul_nginx_image_tag: 1.2
 consul_bin: /bin/consul
 consul_dir: /etc/consul


### PR DESCRIPTION
This sets the default log level to info