### PR TITLE
Add support for Google Cloud DNS

### DIFF
--- a/docs/getting_started/gce.rst
+++ b/docs/getting_started/gce.rst
@@ -86,3 +86,21 @@ Terraform to provision your cluster, ``terraform plan`` to see what will be
 created, and ``terraform apply`` to provision the cluster. Afterwards, you can
 use the instructions in :doc:`getting started <index>` to install
 microservices-infrastructure on your new cluster.
+
+Configuring DNS with Google Cloud DNS
+-------------------------------------
+
+Look at the ``gce.sample.tf`` file (or any of the other sample .tf files) for
+examples on how to configure DNS records for your cluster.
+PS: If you haven't set up a managed zone for the domain you're using, you can
+do that with Terraform as well, just add this extra snippet in your .tf file:
+
+.. code-block:: javascript
+   resource "google_dns_managed_zone" "managed-zone" {
+     name = "my-managed-zone"
+     dns_name = "example.com."
+     description "Managed zone for example.com."
+   }
+
+It should also be possible to create the managed zone manually, in the
+admin panel for Google Cloud.

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -36,7 +36,8 @@ Setting up DNS
 
 Terraform lets you configure DNS for your instances. The DNS provider is
 loosely coupled from the server provider, so you could for example use
-the dnsimple provider for either OpenStack or AWS hosts.
+the dnsimple provider for either OpenStack or AWS hosts, or use the
+Google Cloud DNS provider for DigitalOcean hosts.
 
 These are the supported DNS providers:
 
@@ -44,6 +45,7 @@ These are the supported DNS providers:
    :maxdepth: 1
 
    dnsimple.rst
+   gce.rst
 
 Setting up Authentication and Authorization
 -------------------------------------------

--- a/terraform/aws.sample.tf
+++ b/terraform/aws.sample.tf
@@ -15,13 +15,14 @@ module "aws-dc" {
   worker_count = 3
 }
 
-# Example setup for DNS with dnsimple;
-# module "dnsimple-dns" {
-#   source = "./terraform/dnsimple/dns"
+# Example setup for DNS:
+# module "dnsimple-dns" { # This could also be "google-cloud-dns"
+#   source = "./terraform/dnsimple/dns" # This could also be "./terraform/gce/dns"
 #   short_name = "mi"
 #   control_count = 3
 #   worker_count = 3
 #   domain = "example.com"
-#   control_ips = "${module.aws-dc.control_ips}"
-#   worker_ips = "${module.aws-dc.worker_ips}"
+#   control_ips = "${module.softlayer-hosts.control_ips}"
+#   worker_ips = "${module.softlayer-hosts.worker_ips}"
+#   # managed_zone = "my-managed-zone" # would be required for Google cloud DNS
 # }

--- a/terraform/digitalocean.sample.tf
+++ b/terraform/digitalocean.sample.tf
@@ -16,13 +16,14 @@ module "do-hosts" {
   worker_count = 3
 }
 
-# Example setup for DNS with dnsimple;
-# module "dnsimple-dns" {
-#   source = "./terraform/dnsimple/dns"
+# Example setup for DNS:
+# module "dnsimple-dns" { # This could also be "google-cloud-dns"
+#   source = "./terraform/dnsimple/dns" # This could also be "./terraform/gce/dns"
 #   short_name = "mi"
 #   control_count = 3
 #   worker_count = 3
 #   domain = "example.com"
-#   control_ips = "${module.do-hosts.control_ips}"
-#   worker_ips = "${module.do-hosts.worker_ips}"
+#   control_ips = "${module.softlayer-hosts.control_ips}"
+#   worker_ips = "${module.softlayer-hosts.worker_ips}"
+#   # managed_zone = "my-managed-zone" # would be required for Google cloud DNS
 # }

--- a/terraform/gce.sample.tf
+++ b/terraform/gce.sample.tf
@@ -18,13 +18,14 @@ module "gce-dc" {
   worker_count = 3
 }
 
-# Example setup for DNS with dnsimple;
-# module "dnsimple-dns" {
-#   source = "./terraform/dnsimple/dns"
+# Example setup for DNS:
+# module "dnsimple-dns" { # This could also be "google-cloud-dns"
+#   source = "./terraform/dnsimple/dns" # This could also be "./terraform/gce/dns"
 #   short_name = "mi"
 #   control_count = 3
 #   worker_count = 3
 #   domain = "example.com"
-#   control_ips = "${module.gce-dc.control_ips}"
-#   worker_ips = "${module.gce-dc.worker_ips}"
+#   control_ips = "${module.softlayer-hosts.control_ips}"
+#   worker_ips = "${module.softlayer-hosts.worker_ips}"
+#   # managed_zone = "my-managed-zone" # would be required for Google cloud DNS
 # }

--- a/terraform/gce/dns/main.tf
+++ b/terraform/gce/dns/main.tf
@@ -1,0 +1,33 @@
+variable control_ips {}
+variable worker_ips {}
+variable control_count {}
+variable worker_count {}
+variable domain {}
+variable short_name {}
+variable managed_zone {}
+
+resource "google_dns_record_set" "dns-control" {
+  count = "${var.control_count}"
+  managed_zone = "${var.managed_zone}"
+  name = "${var.short_name}-control-${format("%02d", count.index+1)}.${var.domain}."
+  type = "A"
+  ttl = 60
+  rrdatas = ["${element(split(\",\", var.control_ips), count.index)}"]
+}
+
+resource "google_dns_record_set" "dns-worker" {
+  count = "${var.worker_count}"
+  managed_zone = "${var.managed_zone}"
+  name = "${var.short_name}-worker-${format("%03d", count.index+1)}.${var.domain}."
+  type = "A"
+  ttl = 60
+  rrdatas = ["${element(split(\",\", var.worker_ips), count.index)}"]
+}
+
+resource "google_dns_record_set" "dns-worker-haproxy" {
+  managed_zone = "${var.managed_zone}"
+  name = "${var.short_name}-lb.${var.domain}."
+  type = "A"
+  ttl = 60
+  rrdatas = ["${split(\",\", var.worker_ips)}"]
+}

--- a/terraform/openstack-floating.sample.tf
+++ b/terraform/openstack-floating.sample.tf
@@ -23,13 +23,14 @@ module "dc2-hosts-floating" {
 	external_net_id = ""
 }
 
-# Example setup for DNS with dnsimple;
-# module "dnsimple-dns" {
-#   source = "./terraform/dnsimple/dns"
+# Example setup for DNS:
+# module "dnsimple-dns" { # This could also be "google-cloud-dns"
+#   source = "./terraform/dnsimple/dns" # This could also be "./terraform/gce/dns"
 #   short_name = "mi"
 #   control_count = 3
 #   worker_count = 3
 #   domain = "example.com"
-#   control_ips = "${module.dc2-hosts.control_ips}"
-#   worker_ips = "${module.dc2-hosts.worker_ips}"
+#   control_ips = "${module.softlayer-hosts.control_ips}"
+#   worker_ips = "${module.softlayer-hosts.worker_ips}"
+#   # managed_zone = "my-managed-zone" # would be required for Google cloud DNS
 # }

--- a/terraform/openstack.sample.tf
+++ b/terraform/openstack.sample.tf
@@ -24,13 +24,14 @@ module "dc2-hosts" {
   glusterfs_volume_size = 100
 }
 
-# Example setup for DNS with dnsimple;
-# module "dnsimple-dns" {
-#   source = "./terraform/dnsimple/dns"
+# Example setup for DNS:
+# module "dnsimple-dns" { # This could also be "google-cloud-dns"
+#   source = "./terraform/dnsimple/dns" # This could also be "./terraform/gce/dns"
 #   short_name = "mi"
 #   control_count = 3
 #   worker_count = 3
 #   domain = "example.com"
-#   control_ips = "${module.dc2-hosts.control_ips}"
-#   worker_ips = "${module.dc2-hosts.worker_ips}"
+#   control_ips = "${module.softlayer-hosts.control_ips}"
+#   worker_ips = "${module.softlayer-hosts.worker_ips}"
+#   # managed_zone = "my-managed-zone" # would be required for Google cloud DNS
 # }

--- a/terraform/softlayer.sample.tf
+++ b/terraform/softlayer.sample.tf
@@ -16,13 +16,14 @@ module "softlayer-hosts" {
   worker_count = 3
 }
 
-# Example setup for DNS with dnsimple;
-# module "dnsimple-dns" {
-#   source = "./terraform/dnsimple/dns"
+# Example setup for DNS:
+# module "dnsimple-dns" { # This could also be "google-cloud-dns"
+#   source = "./terraform/dnsimple/dns" # This could also be "./terraform/gce/dns"
 #   short_name = "mi"
 #   control_count = 3
 #   worker_count = 3
 #   domain = "example.com"
 #   control_ips = "${module.softlayer-hosts.control_ips}"
 #   worker_ips = "${module.softlayer-hosts.worker_ips}"
+#   # managed_zone = "my-managed-zone" # this would be required for Google cloud DNS
 # }

--- a/terraform/vsphere.sample.tf
+++ b/terraform/vsphere.sample.tf
@@ -20,13 +20,14 @@ module "vsphere-dc" {
   consul_dc = ""
 }
 
-# Example setup for DNS with dnsimple;
-# module "dnsimple-dns" {
-#   source = "./terraform/dnsimple/dns"
+# Example setup for DNS:
+# module "dnsimple-dns" { # This could also be "google-cloud-dns"
+#   source = "./terraform/dnsimple/dns" # This could also be "./terraform/gce/dns"
 #   short_name = "mi"
 #   control_count = 3
 #   worker_count = 3
 #   domain = "example.com"
-#   control_ips = "${module.vsphere-dc.control_ips}"
-#   worker_ips = "${module.vsphere-dc.worker_ips}"
+#   control_ips = "${module.softlayer-hosts.control_ips}"
+#   worker_ips = "${module.softlayer-hosts.worker_ips}"
+#   # managed_zone = "my-managed-zone" # would be required for Google cloud DNS
 # }


### PR DESCRIPTION
This can be used instead of DNSimple for DNS records.
Also adds some documentation for the provider.