### PR TITLE
Feature/566 consul leader

### DIFF
--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -1,33 +1,119 @@
 ---
+# CHECK SECURITY - when customizing you should leave this in. If you take it out
+# and forget to specify security.yml, security could be turned off on components
+# in your cluster!
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: check for security
+      when: security_enabled is not defined or not security_enabled
+      fail:
+        msg: |
+          Security is not enabled. Please run `security-setup` in the root
+          directory and re-run this playbook with the `--extra-vars`/`-e` option
+          pointing to your `security.yml` (e.g., `-e @security.yml`)
+
+# BASICS - we need every node in the cluster to have common software running to
+# increase stability and enable service discovery. You can look at the
+# documentation for each of these components in their README file in the
+# `roles/` directory, or by checking the online documentation at
+# microservices-infrastructure.readthedocs.org.
 - hosts: all
   vars:
-    consul_servers_group: role=control
+    # consul_acl_datacenter should be set to the datacenter you want to control
+    # Consul ACLs. If you only have one datacenter, set it to that or remove
+    # this variable.
+    # consul_acl_datacenter: your_primary_datacenter
+
+    # consul_dns_domain is repeated across these plays so that all the
+    # components know what information to use for this values to help with
+    # service discovery.
     consul_dns_domain: consul
-    consul_dc: vagrant
-    consul_acl_datacenter: vagrant
-    consul_bootstrap_expect: 1
-    mesos_cluster: vagrant
-    mesos_mode: mixed
-    provider: vagrant
-  pre_tasks:
-    - name: set vagrant ip addresses in inventory
-      set_fact:
-        private_ipv4: "{{ vagrant_private_ipv4 }}"
-        public_ipv4: "{{ vagrant_private_ipv4 }}"
+    consul_servers_group: role=control
   roles:
     - common
     - collectd
     - logrotate
     - consul-template
     - docker
-    - dnsmasq
+    - logstash
     - nginx
     - consul
-    - logstash
+    - etcd
+    - dnsmasq
+
+# ROLES - after provisioning the software that's common to all hosts, we do
+# specialized hosts. This configuration has two major groups: control nodes and
+# worker nodes. We provision the worker nodes first so that we don't create any
+# race conditions. This could happen in the Mesos components - if there are no
+# worker nodes when trying to schedule control software, the deployment process
+# would hang.
+#
+# The worker role itself has a minimal configuration, as it's designed mainly to
+# run software that the Mesos leader shedules. It also forwards traffic to
+# globally known ports configured through Marathon.
+- hosts: role=worker
+  # role=worker hosts are a subset of "all". Since we already gathered facts on
+  # all servers, we can skip it here to speed up the deployment.
+  gather_facts: no
+  vars:
+    consul_dns_domain: consul
+    mesos_mode: follower
+
+    # Set this to whatever domain you want to reach haproxy from; it should be
+    # in this format: [short-name]-lb.[domain], where [short-name] and [domain]
+    # are the same as configured in terraform.
+    # In this example, short-name is "mi" and domain is "example.com":
+    haproxy_domain: mi-lb.example.com
+  roles:
+    - calico
+    - mesos
+    - haproxy
+
+# the control nodes are necessarily more complex than the worker nodes, and have
+# ZooKeeper, Mesos, and Marathon leaders. In addition, they control Vault to
+# manage secrets in the cluster. These servers do not run applications by
+# themselves, they only schedule work. That said, there should be at least 3 of
+# them (and always an odd number) so that ZooKeeper can get and keep a quorum.
+- hosts: role=control
+  gather_facts: no
+  vars:
+    consul_dns_domain: consul
+    consul_servers_group: role=control
+    mesos_leaders_group: role=control
+    mesos_mode: leader
+    zookeeper_server_group: role=control
+    # ansible groups for service configuration
+    etcd_group_name: role=control
+    master_group_name: role=control
+    minion_group_name: role=worker
+
+    etcd_url_scheme: http
+
+    cluster_name: cluster.local
+    kube_service_addresses: 10.254.0.0/16
+  roles:
     - vault
     - zookeeper
     - mesos
     - marathon
     - chronos
     - mantlui
-    - k8s-master
+    - {role: k8s-master, tags: k8s}
+
+# GlusterFS has to be provisioned in reverse order from Mesos: servers then
+# clients.
+- hosts: role=control
+  gather_facts: no
+  vars:
+    consul_dns_domain: consul
+    glusterfs_mode: server
+  roles:
+    - glusterfs
+
+- hosts: role=worker
+  vars:
+    consul_dns_domain: consul
+    glusterfs_mode: client
+  roles:
+    - glusterfs

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -1,0 +1,33 @@
+---
+- hosts: all
+  vars:
+    consul_servers_group: role=control
+    consul_dns_domain: consul
+    consul_dc: vagrant
+    consul_acl_datacenter: vagrant
+    consul_bootstrap_expect: 1
+    mesos_cluster: vagrant
+    mesos_mode: mixed
+    provider: vagrant
+  pre_tasks:
+    - name: set vagrant ip addresses in inventory
+      set_fact:
+        private_ipv4: "{{ vagrant_private_ipv4 }}"
+        public_ipv4: "{{ vagrant_private_ipv4 }}"
+  roles:
+    - common
+    - collectd
+    - logrotate
+    - consul-template
+    - docker
+    - dnsmasq
+    - nginx
+    - consul
+    - logstash
+    - vault
+    - zookeeper
+    - mesos
+    - marathon
+    - chronos
+    - mantlui
+    - k8s-master

--- a/kubernetes_vars.yml
+++ b/kubernetes_vars.yml
@@ -1,0 +1,64 @@
+# ansible remote user account
+# ansible_ssh_user: centos
+
+# ansible groups for service configuration
+etcd_group_name: role=master
+master_group_name: role=master
+minion_group_name: role=node
+
+# Kubernetes build to use, stable is used by default. 
+# Place "testing" here to use latest build avialable.
+kube_build: stable
+
+# Users to create for basic auth in Kubernetes API via HTTP
+kube_users:
+  kube:
+    pass: changeme
+    role: admin
+  root:
+    pass: changeme
+    role: admin
+
+# Kubernetes cluster name, also will be used as DNS domain
+cluster_name: cluster.local
+
+# Kubernetes internal network for services, unused block of space.
+kube_service_addresses: 10.254.0.0/16
+
+# internal network (optional). When used, it will assign IP
+# addresses from this range to individual pods.
+# This network must be unused in your network infrastructure!
+overlay_network_subnet: 4.0.0.0
+
+# internal network total size (optional). This is the prefix of the
+# entire overlay network.  So the entirety of 4.0.0.0/16 must be
+# unused in your environment.
+overlay_network_prefix: 16
+
+# internal network node size allocation (optional). This is the size allocated
+# to each node on your network.  With these defaults you should have
+# room for 4096 nodes with 254 pods per node.
+overlay_network_host_prefix: 24
+
+# Internal DNS configuration.
+# Kubernetes can create and mainatain its own DNS server to resolve service names
+# into appropriate IP addresses. It's highly advisable to run such DNS server,
+# as it greatly simplifies configuration of your applications - you can use
+# service names instead of magic environment variables.
+# You still must manually configure all your containers to use this DNS server,
+# Kubernetes won't do this for you (yet).
+
+# Turn this varable to 'false' to disable whole DNS configuration.
+dns_setup: true
+
+# Number of replicas of DNS instances started on kubernetes
+dns_replicas: 1
+
+# Set to 'false' to disable default Kubernetes UI setup
+enable_ui: true
+
+# Set to 'false' to disable default Elasticsearch + Kibana logging setup
+enable_logging: true
+
+# Set to "false' to disable default Monitoring (cAdvisor + heapster + influxdb + grafana)
+enable_monitoring: true

--- a/kubernetes_vars.yml
+++ b/kubernetes_vars.yml
@@ -2,9 +2,9 @@
 # ansible_ssh_user: centos
 
 # ansible groups for service configuration
-etcd_group_name: role=master
-master_group_name: role=master
-minion_group_name: role=node
+etcd_group_name: role=control
+master_group_name: role=control
+minion_group_name: role=worker
 
 # Kubernetes build to use, stable is used by default. 
 # Place "testing" here to use latest build avialable.

--- a/playbooks/consul-reelect-leader.yml
+++ b/playbooks/consul-reelect-leader.yml
@@ -1,0 +1,20 @@
+---
+- hosts: role=control
+  tasks:
+  - name: consul | Stop service
+    sudo: yes
+    service:
+      name: consul
+      enabled: yes
+      state: stopped
+
+  - name: fix | Remove raft database
+    sudo: yes
+    shell: rm -rf /var/lib/consul/raft/*
+
+  - name: consul | Start service
+    sudo: yes
+    service:
+      name: consul
+      enabled: yes
+      state: started

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -24,8 +24,7 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - docker-engine-1.7.0
-    - docker-selinux
+    - docker-1.7.1
   tags:
     - docker
     - bootstrap
@@ -83,7 +82,7 @@
       [Service]
       EnvironmentFile=-/etc/sysconfig/docker
       ExecStart=
-      ExecStart=/usr/bin/docker -d -H fd:// $other_arg
+      ExecStart=/usr/bin/docker -d $other_arg
   notify:
     - reload docker
   tags:

--- a/roles/k8s-master/handlers/main.yml
+++ b/roles/k8s-master/handlers/main.yml
@@ -1,0 +1,33 @@
+---
+- name: restart daemons
+  sudo: yes
+  command: /bin/true
+  notify:
+    - restart apiserver
+    - restart controller-manager
+    - restart scheduler
+    - restart proxy
+
+- name: restart apiserver
+  sudo: yes
+  service:
+    name: kube-apiserver
+    state: restarted
+
+- name: restart controller-manager
+  sudo: yes
+  service:
+    name: kube-controller-manager
+    state: restarted
+
+- name: restart scheduler
+  sudo: yes
+  service:
+    name: kube-scheduler
+    state: restarted
+
+- name: restart proxy
+  sudo: yes
+  service:
+    name: kube-proxy
+    state: restarted

--- a/roles/k8s-master/meta/main.yml
+++ b/roles/k8s-master/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: common }
+  - { role: kubernetes }

--- a/roles/k8s-master/tasks/main.yml
+++ b/roles/k8s-master/tasks/main.yml
@@ -1,0 +1,149 @@
+---
+- include: stable.yml
+  when: kube_build == "stable"
+
+- include: testing.yml
+  when: kube_build == "testing"
+
+- name: enable capability for kube-apiserver to bind to port below 1024
+  sudo: yes
+  capabilities:
+    capability: cap_net_bind_service+ep
+    path: /usr/bin/kube-apiserver
+    state: present
+  when: "{{ kube_master_port | int  }} < 1024"
+  notify:
+    - restart daemons
+  tags:
+    - master
+
+- name: get the node token values from token files
+  sudo: yes
+  slurp:
+    src: "{{ kube_token_dir }}/{{ item }}-{{ inventory_hostname }}.token"
+  with_items:
+    - "system:controller_manager"
+    - "system:scheduler"
+    - "system:kubectl"
+    - "system:proxy"
+  register: tokens
+  delegate_to: "{{ groups[master_group_name][0] }}"
+  tags:
+    - master
+
+- name: Set token facts
+  set_fact:
+    controller_manager_token: "{{ tokens.results[0].content|b64decode }}"
+    scheduler_token: "{{ tokens.results[1].content|b64decode }}"
+    kubectl_token: "{{ tokens.results[2].content|b64decode }}"
+    proxy_token: "{{ tokens.results[3].content|b64decode }}"
+  tags:
+    - master
+
+- name: write the config files for api server
+  sudo: yes
+  template: src=apiserver.j2 dest={{ kube_config_dir }}/apiserver
+  notify:
+    - restart daemons
+  tags:
+    - master
+
+- name: write config file for controller-manager
+  sudo: yes
+  template: src=controller-manager.j2 dest={{ kube_config_dir }}/controller-manager
+  notify:
+    - restart controller-manager
+  tags:
+    - master
+
+- name: write the kubecfg (auth) file for controller-manager
+  sudo: yes
+  template: src=controller-manager.kubeconfig.j2 dest={{ kube_config_dir }}/controller-manager.kubeconfig
+  notify:
+    - restart controller-manager
+  tags:
+    - master
+
+- name: write the config file for scheduler
+  sudo: yes
+  template: src=scheduler.j2 dest={{ kube_config_dir }}/scheduler
+  notify:
+    - restart scheduler
+  tags:
+    - master
+
+- name: write the kubecfg (auth) file for scheduler
+  sudo: yes
+  template: src=scheduler.kubeconfig.j2 dest={{ kube_config_dir }}/scheduler.kubeconfig
+  notify:
+    - restart scheduler
+  tags:
+    - master
+
+- name: write the kubecfg (auth) file for kubectl
+  sudo: yes
+  template: src=kubectl.kubeconfig.j2 dest={{ kube_config_dir }}/kubectl.kubeconfig
+  tags:
+    - master
+
+- name: write the config files for proxy
+  sudo: yes
+  template: src=proxy.j2 dest={{ kube_config_dir }}/proxy
+  notify:
+    - restart daemons
+  tags:
+    - master
+
+- name: write the kubecfg (auth) file for proxy
+  sudo: yes
+  template: src=proxy.kubeconfig.j2 dest={{ kube_config_dir }}/proxy.kubeconfig
+  tags:
+    - master
+
+- name: populate users for basic auth in API
+  sudo: yes
+  lineinfile:
+    dest: "{{ kube_users_dir }}/known_users.csv"
+    create: yes
+    line: '{{ item.value.pass }},{{ item.key }},{{ item.value.role }}'
+  with_dict: "{{ kube_users }}"
+  notify:
+    - restart apiserver
+  tags:
+    - master
+
+- name: Enable apiserver
+  sudo: yes
+  service:
+    name: kube-apiserver
+    enabled: yes
+    state: started
+  tags:
+    - master
+
+- name: Enable controller-manager
+  sudo: yes
+  service:
+    name: kube-controller-manager
+    enabled: yes
+    state: started
+  tags:
+    - master
+
+- name: Enable scheduler
+  sudo: yes
+  service:
+    name: kube-scheduler
+    enabled: yes
+    state: started
+  tags:
+    - master
+
+- name: Enable kube-proxy
+  sudo: yes
+  service:
+    name: kube-proxy
+    enabled: yes
+    state: started
+  tags:
+    - master

--- a/roles/k8s-master/tasks/stable.yml
+++ b/roles/k8s-master/tasks/stable.yml
@@ -1,0 +1,9 @@
+- name: install kubernetes master
+  sudo: yes
+  yum:
+    pkg="kubernetes-{{ kube_version }}"
+    state=present
+  notify:
+    - restart daemons
+  tags:
+    - master

--- a/roles/k8s-master/tasks/testing.yml
+++ b/roles/k8s-master/tasks/testing.yml
@@ -1,0 +1,10 @@
+- name: install latest kubernetes master 
+  sudo: yes
+  yum:
+    pkg="kubernetes"
+    state=latest
+    enablerepo="virt7-docker-common-candidate"
+  notify:
+    - restart daemons
+  tags:
+    - master

--- a/roles/k8s-master/templates/apiserver.j2
+++ b/roles/k8s-master/templates/apiserver.j2
@@ -1,0 +1,26 @@
+###
+# kubernetes system config
+#
+# The following values are used to configure the kube-apiserver
+#
+
+# The address on the local server to listen to.
+KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1"
+
+# The port on the local server to listen on.
+KUBE_API_PORT="--secure-port={{ kube_master_port }}"
+
+# Port minions listen on
+# KUBELET_PORT="--kubelet_port=10250"
+
+# Address range to use for services
+KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range={{ kube_service_addresses }}"
+
+# Location of the etcd cluster
+KUBE_ETCD_SERVERS="--etcd_servers={% for node in groups[etcd_group_name] %}{{ etcd_url_scheme }}://{{ node }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+
+# default admission control policies
+KUBE_ADMISSION_CONTROL="--admission_control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
+
+# Add you own!
+KUBE_API_ARGS="--tls_cert_file={{ kube_cert_dir }}/server.crt --tls_private_key_file={{ kube_cert_dir }}/server.key --client_ca_file={{ kube_cert_dir }}/ca.crt --token_auth_file={{ kube_token_dir }}/known_tokens.csv --basic-auth-file={{ kube_users_dir }}/known_users.csv --service_account_key_file={{ kube_cert_dir }}/server.crt"

--- a/roles/k8s-master/templates/apiserver.j2
+++ b/roles/k8s-master/templates/apiserver.j2
@@ -17,7 +17,7 @@ KUBE_API_PORT="--secure-port={{ kube_master_port }}"
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range={{ kube_service_addresses }}"
 
 # Location of the etcd cluster
-KUBE_ETCD_SERVERS="--etcd_servers={% for node in groups[etcd_group_name] %}{{ etcd_url_scheme }}://{{ node }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+KUBE_ETCD_SERVERS="--etcd_servers={{ etcd_url_scheme }}://etcd.service.{{ consul_dns_domain }}:{{ etcd_client_port }}"
 
 # default admission control policies
 KUBE_ADMISSION_CONTROL="--admission_control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"

--- a/roles/k8s-master/templates/controller-manager.j2
+++ b/roles/k8s-master/templates/controller-manager.j2
@@ -1,0 +1,7 @@
+###
+# The following values are used to configure the kubernetes controller-manager
+
+# defaults from config and apiserver should be adequate
+
+# Add you own!
+KUBE_CONTROLLER_MANAGER_ARGS="--kubeconfig={{ kube_config_dir }}/controller-manager.kubeconfig --service_account_private_key_file={{ kube_cert_dir }}/server.key --root_ca_file={{ kube_cert_dir }}/ca.crt"

--- a/roles/k8s-master/templates/controller-manager.kubeconfig.j2
+++ b/roles/k8s-master/templates/controller-manager.kubeconfig.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+current-context: controller-manager-to-{{ cluster_name }}
+preferences: {}
+clusters:
+- cluster:
+    certificate-authority: {{ kube_cert_dir }}/ca.crt
+    server: https://{{ groups[master_group_name][0] }}:{{ kube_master_port }}
+  name: {{ cluster_name }}
+contexts:
+- context:
+    cluster: {{ cluster_name }}
+    user: controller-manager
+  name: controller-manager-to-{{ cluster_name }}
+users:
+- name: controller-manager
+  user:
+    token: {{ controller_manager_token }}

--- a/roles/k8s-master/templates/kubectl.kubeconfig.j2
+++ b/roles/k8s-master/templates/kubectl.kubeconfig.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+current-context: kubectl-to-{{ cluster_name }}
+preferences: {}
+clusters:
+- cluster:
+    certificate-authority-data: {{ kube_ca_cert|b64encode }}
+    server: https://{{ groups[master_group_name][0] }}:{{ kube_master_port }}
+  name: {{ cluster_name }}
+contexts:
+- context:
+    cluster: {{ cluster_name }}
+    user: kubectl
+  name: kubectl-to-{{ cluster_name }}
+users:
+- name: kubectl
+  user:
+    token: {{ kubectl_token }}

--- a/roles/k8s-master/templates/proxy.j2
+++ b/roles/k8s-master/templates/proxy.j2
@@ -1,0 +1,7 @@
+###
+# kubernetes proxy config
+
+# default config should be adequate
+
+# Add your own!
+KUBE_PROXY_ARGS="--kubeconfig={{ kube_config_dir }}/proxy.kubeconfig"

--- a/roles/k8s-master/templates/proxy.kubeconfig.j2
+++ b/roles/k8s-master/templates/proxy.kubeconfig.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+current-context: proxy-to-{{ cluster_name }}
+preferences: {}
+contexts:
+- context:
+    cluster: {{ cluster_name }}
+    user: proxy
+  name: proxy-to-{{ cluster_name }}
+clusters:
+- cluster:
+    certificate-authority: {{ kube_cert_dir }}/ca.crt
+    server: https://{{ groups[master_group_name][0] }}:{{ kube_master_port }}
+  name: {{ cluster_name }}
+users:
+- name: proxy
+  user:
+    token: {{ proxy_token }}

--- a/roles/k8s-master/templates/scheduler.j2
+++ b/roles/k8s-master/templates/scheduler.j2
@@ -1,0 +1,7 @@
+###
+# kubernetes scheduler config
+
+# default config should be adequate
+
+# Add your own!
+KUBE_SCHEDULER_ARGS="--kubeconfig={{ kube_config_dir }}/scheduler.kubeconfig"

--- a/roles/k8s-master/templates/scheduler.kubeconfig.j2
+++ b/roles/k8s-master/templates/scheduler.kubeconfig.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+current-context: scheduler-to-{{ cluster_name }}
+preferences: {}
+clusters:
+- cluster:
+    certificate-authority: {{ kube_cert_dir }}/ca.crt
+    server: https://{{ groups[master_group_name][0] }}:{{ kube_master_port }}
+  name: {{ cluster_name }}
+contexts:
+- context:
+    cluster: {{ cluster_name }}
+    user: scheduler
+  name: scheduler-to-{{ cluster_name }}
+users:
+- name: scheduler
+  user:
+    token: {{ scheduler_token }}

--- a/roles/kubernetes/defaults/main.yml
+++ b/roles/kubernetes/defaults/main.yml
@@ -1,0 +1,50 @@
+# The version of software to install for Kubernetes.
+# When testing repo is used, state is "latest", so this has no effect.
+kube_version: 1.0.0
+
+# Kubernetes services logging level, integer from 0 to 4, where 4 is highest
+# Applys to all services globally. Be carefull with highest log level,
+# log sizes are growing pretty fast even without real workload.
+kube_log_level: 0
+
+# This directory is where all the additional scripts go
+# that Kubernetes normally puts in /srv/kubernetes.
+# This puts them in a sane location
+kube_script_dir: /usr/libexec/kubernetes
+
+# This directory is where all the additional config stuff goes
+# the kubernetes normally puts in /srv/kubernets.
+# This puts them in a sane location.
+# Editting this value will almost surely break something. Don't
+# change it. Things like the systemd scripts are hard coded to
+# look in here. Don't do it.
+kube_config_dir: /etc/kubernetes
+
+# The port the API Server will be listening on.
+kube_master_port: 443
+
+# This is where all the cert scripts and certs will be located
+kube_cert_dir: "{{ kube_config_dir }}/certs"
+
+# This is where all of the bearer tokens will be stored
+kube_token_dir: "{{ kube_config_dir }}/tokens"
+
+# This is where to save basic auth file
+kube_users_dir: "{{ kube_config_dir }}/users"
+
+# This is where you can drop yaml/json files and the kubelet will run those
+# pods on startup
+kube_manifest_dir: "{{ kube_config_dir }}/manifests"
+
+# This is the group that the cert creation scripts chgrp the
+# cert files to. Not really changable...
+kube_cert_group: kube-cert
+
+dns_domain: "{{ cluster_name }}"
+
+# IP address of the DNS server.
+# Kubernetes will create a pod with several containers, serving as the DNS
+# server and expose it under this IP address. The IP address must be from
+# the range specified as kube_service_addresses. This magic will actually
+# pick the 10th ip address in the kube_service_addresses range and use that.
+dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(253)|ipaddr('address') }}"

--- a/roles/kubernetes/files/kube-gen-token.sh
+++ b/roles/kubernetes/files/kube-gen-token.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+token_dir=${TOKEN_DIR:-/var/srv/kubernetes}
+token_file="${token_dir}/known_tokens.csv"
+
+create_accounts=($@)
+
+touch "${token_file}"
+for account in "${create_accounts[@]}"; do
+  if grep ",${account}," "${token_file}" ; then
+    continue
+  fi
+  token=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
+  echo "${token},${account},${account}" >> "${token_file}"
+  echo "${token}" > "${token_dir}/${account}.token"
+  echo "Added ${account}"
+done

--- a/roles/kubernetes/files/make-ca-cert.sh
+++ b/roles/kubernetes/files/make-ca-cert.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Caller should set in the ev:
+# MASTER_IP - this may be an ip or things like "_use_gce_external_ip_"
+# DNS_DOMAIN - which will be passed to minions in --cluster_domain
+# SERVICE_CLUSTER_IP_RANGE - where all service IPs are allocated
+# MASTER_NAME - I'm not sure what it is...
+
+# Also the following will be respected
+# CERT_DIR - where to place the finished certs
+# CERT_GROUP - who the group owner of the cert files should be
+
+cert_ip="${MASTER_IP:="${1}"}"
+master_name="${MASTER_NAME:="kubernetes"}"
+service_range="${SERVICE_CLUSTER_IP_RANGE:="10.0.0.0/16"}"
+dns_domain="${DNS_DOMAIN:="cluster.local"}"
+cert_dir="${CERT_DIR:-"/srv/kubernetes"}"
+cert_group="${CERT_GROUP:="kube-cert"}"
+
+# The following certificate pairs are created:
+#
+#  - ca (the cluster's certificate authority)
+#  - server
+#  - kubelet
+#  - kubecfg (for kubectl)
+#
+# TODO(roberthbailey): Replace easyrsa with a simple Go program to generate
+# the certs that we need.
+
+# TODO: Add support for discovery on other providers?
+if [ "$cert_ip" == "_use_gce_external_ip_" ]; then
+  cert_ip=$(curl -s -H Metadata-Flavor:Google http://metadata.google.internal./computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+fi
+
+if [ "$cert_ip" == "_use_aws_external_ip_" ]; then
+  cert_ip=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+fi
+
+if [ "$cert_ip" == "_use_azure_dns_name_" ]; then
+  cert_ip=$(uname -n | awk -F. '{ print $2 }').cloudapp.net
+fi
+
+tmpdir=$(mktemp -d --tmpdir kubernetes_cacert.XXXXXX)
+trap 'rm -rf "${tmpdir}"' EXIT
+cd "${tmpdir}"
+
+# TODO: For now, this is a patched tool that makes subject-alt-name work, when
+# the fix is upstream  move back to the upstream easyrsa.  This is cached in GCS
+# but is originally taken from:
+#   https://github.com/brendandburns/easy-rsa/archive/master.tar.gz
+#
+# To update, do the following:
+# curl -o easy-rsa.tar.gz https://github.com/brendandburns/easy-rsa/archive/master.tar.gz
+# gsutil cp easy-rsa.tar.gz gs://kubernetes-release/easy-rsa/easy-rsa.tar.gz
+# gsutil acl ch -R -g all:R gs://kubernetes-release/easy-rsa/easy-rsa.tar.gz
+#
+# Due to GCS caching of public objects, it may take time for this to be widely
+# distributed.
+
+# Calculate the first ip address in the service range
+octects=($(echo "${service_range}" | sed -e 's|/.*||' -e 's/\./ /g'))
+((octects[3]+=1))
+service_ip=$(echo "${octects[*]}" | sed 's/ /./g')
+
+# Determine appropriete subject alt names
+sans="IP:${cert_ip},IP:${service_ip},DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.${dns_domain},DNS:${master_name}"
+
+curl -L -O https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz > /dev/null 2>&1
+tar xzf easy-rsa.tar.gz > /dev/null
+cd easy-rsa-master/easyrsa3
+
+(./easyrsa init-pki > /dev/null 2>&1
+ ./easyrsa --batch "--req-cn=${cert_ip}@$(date +%s)" build-ca nopass > /dev/null 2>&1
+ ./easyrsa --subject-alt-name="${sans}" build-server-full "${master_name}" nopass > /dev/null 2>&1
+ ./easyrsa build-client-full kubelet nopass > /dev/null 2>&1
+ ./easyrsa build-client-full kubecfg nopass > /dev/null 2>&1) || {
+ # If there was an error in the subshell, just die.
+ # TODO(roberthbailey): add better error handling here
+ echo "=== Failed to generate certificates: Aborting ==="
+ exit 2
+ }
+
+mkdir -p "$cert_dir"
+
+cp -p pki/ca.crt "${cert_dir}/ca.crt"
+cp -p "pki/issued/${master_name}.crt" "${cert_dir}/server.crt" > /dev/null 2>&1
+cp -p "pki/private/${master_name}.key" "${cert_dir}/server.key" > /dev/null 2>&1
+cp -p pki/issued/kubecfg.crt "${cert_dir}/kubecfg.crt"
+cp -p pki/private/kubecfg.key "${cert_dir}/kubecfg.key"
+cp -p pki/issued/kubelet.crt "${cert_dir}/kubelet.crt"
+cp -p pki/private/kubelet.key "${cert_dir}/kubelet.key"
+
+CERTS=("ca.crt" "server.key" "server.crt" "kubelet.key" "kubelet.crt" "kubecfg.key" "kubecfg.crt")
+for cert in "${CERTS[@]}"; do
+  chgrp "${cert_group}" "${cert_dir}/${cert}"
+  chmod 660 "${cert_dir}/${cert}"
+done

--- a/roles/kubernetes/meta/main.yml
+++ b/roles/kubernetes/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: common }
+  - { role: etcd }

--- a/roles/kubernetes/tasks/gen_certs.yml
+++ b/roles/kubernetes/tasks/gen_certs.yml
@@ -1,0 +1,45 @@
+---
+#- name: Get create ca cert script from Kubernetes
+#  get_url:
+#    url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
+#    dest={{ kube_script_dir }}/make-ca-cert.sh mode=0500
+#    force=yes
+
+- name: certs | install cert generation script
+  sudo: yes
+  copy:
+    src=make-ca-cert.sh
+    dest={{ kube_script_dir }}
+    mode=0500
+  changed_when: false
+
+# FIXME This only generates a cert for one master...
+- name: certs | run cert generation script
+  sudo: yes
+  command:
+    "{{ kube_script_dir }}/make-ca-cert.sh {{ inventory_hostname }}"
+  args:
+    creates: "{{ kube_cert_dir }}/server.crt"
+  environment:
+    MASTER_IP: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+    MASTER_NAME: "{{ inventory_hostname }}"
+    DNS_DOMAIN: "{{ dns_domain }}"
+    SERVICE_CLUSTER_IP_RANGE: "{{ kube_service_addresses }}"
+    CERT_DIR: "{{ kube_cert_dir }}"
+    CERT_GROUP: "{{ kube_cert_group }}"
+
+- name: certs | check certificate permissions
+  sudo: yes
+  file:
+    path={{ item }}
+    group={{ kube_cert_group }}
+    owner=kube
+    mode=0440
+  with_items:
+    - "{{ kube_cert_dir }}/ca.crt"
+    - "{{ kube_cert_dir }}/server.crt"
+    - "{{ kube_cert_dir }}/server.key"
+    - "{{ kube_cert_dir }}/kubecfg.crt"
+    - "{{ kube_cert_dir }}/kubecfg.key"
+    - "{{ kube_cert_dir }}/kubelet.crt"
+    - "{{ kube_cert_dir }}/kubelet.key"

--- a/roles/kubernetes/tasks/gen_tokens.yml
+++ b/roles/kubernetes/tasks/gen_tokens.yml
@@ -1,0 +1,33 @@
+---
+- name: tokens | copy the token gen script
+  sudo: yes
+  copy:
+    src=kube-gen-token.sh
+    dest={{ kube_script_dir }}
+    mode=u+x
+
+- name: tokens | generate tokens for master components
+  sudo: yes
+  command: "{{ kube_script_dir }}/kube-gen-token.sh {{ item[0] }}-{{ item[1] }}"
+  environment:
+    TOKEN_DIR: "{{ kube_token_dir }}"
+  with_nested:
+    - [ "system:controller_manager", "system:scheduler", "system:kubectl", 'system:proxy' ]
+    - "{{ groups[master_group_name] }}"
+  register: gentoken
+  changed_when: "'Added' in gentoken.stdout"
+  notify:
+    - restart daemons
+
+- name: tokens | generate tokens for node components
+  sudo: yes
+  command: "{{ kube_script_dir }}/kube-gen-token.sh {{ item[0] }}-{{ item[1] }}"
+  environment:
+    TOKEN_DIR: "{{ kube_token_dir }}"
+  with_nested:
+    - [ 'system:kubelet', 'system:proxy' ]
+    - "{{ groups[minion_group_name] }}"
+  register: gentoken
+  changed_when: "'Added' in gentoken.stdout"
+  notify:
+    - restart daemons

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: create kubernetes config directory
+  sudo: yes
+  file: path={{ kube_config_dir }} state=directory
+
+- name: create kubernetes script directory
+  sudo: yes
+  file: path={{ kube_script_dir }} state=directory
+
+- name: Make sure manifest directory exists
+  sudo: yes
+  file: path={{ kube_manifest_dir }} state=directory
+
+- name: write the global config file
+  sudo: yes
+  template:
+    src: config.j2
+    dest: "{{ kube_config_dir }}/config"
+  notify:
+    - restart daemons
+  tags:
+    - kubernetes
+
+- include: secrets.yml
+  tags:
+    - secrets

--- a/roles/kubernetes/tasks/secrets.yml
+++ b/roles/kubernetes/tasks/secrets.yml
@@ -1,0 +1,58 @@
+---
+- name: certs | create system kube-cert groups
+  sudo: yes
+  group: name={{ kube_cert_group }} state=present system=yes
+
+- name: create system kube user
+  sudo: yes
+  user:
+    name=kube
+    comment="Kubernetes user"
+    shell=/sbin/nologin
+    state=present
+    system=yes
+    groups={{ kube_cert_group }}
+
+- name: certs | make sure the certificate directory exits
+  sudo: yes
+  file:
+    path={{ kube_cert_dir }}
+    state=directory
+    mode=o-rwx
+    group={{ kube_cert_group }}
+
+- name: tokens | make sure the tokens directory exits
+  sudo: yes
+  file:
+    path={{ kube_token_dir }}
+    state=directory
+    mode=o-rwx
+    group={{ kube_cert_group }}
+
+- include: gen_certs.yml
+  sudo: yes
+  run_once: true
+  when: inventory_hostname == groups[master_group_name][0]
+
+- name: Read back the CA certificate
+  sudo: yes
+  slurp:
+    src: "{{ kube_cert_dir }}/ca.crt"
+  register: ca_cert
+  run_once: true
+  delegate_to: "{{ groups[master_group_name][0] }}"
+
+- name: certs | register the CA certificate as a fact for later use
+  set_fact:
+    kube_ca_cert: "{{ ca_cert.content|b64decode }}"
+
+- name: certs | write CA certificate everywhere
+  sudo: yes
+  copy: content="{{ kube_ca_cert }}" dest="{{ kube_cert_dir }}/ca.crt"
+  notify:
+    - restart daemons
+
+- include: gen_tokens.yml
+  sudo: yes
+  run_once: true
+  when: inventory_hostname == groups[master_group_name][0]

--- a/roles/kubernetes/templates/config.j2
+++ b/roles/kubernetes/templates/config.j2
@@ -1,0 +1,26 @@
+###
+# kubernetes system config
+#
+# The following values are used to configure various aspects of all
+# kubernetes services, including
+#
+#   kube-apiserver.service
+#   kube-controller-manager.service
+#   kube-scheduler.service
+#   kubelet.service
+#   kube-proxy.service
+
+# Comma separated list of nodes in the etcd cluster
+KUBE_ETCD_SERVERS="--etcd_servers={{ etcd_url_scheme }}://{{ groups[etcd_group_name][0] }}:{{ etcd_client_port }}"
+
+# logging to stderr means we get it in the systemd journal
+KUBE_LOGTOSTDERR="--logtostderr=true"
+
+# journal message level, 0 is debug
+KUBE_LOG_LEVEL="--v={{ kube_log_level }}"
+
+# Should this cluster be allowed to run privileged docker containers
+KUBE_ALLOW_PRIV="--allow_privileged=true"
+
+# How the replication controller, scheduler, and proxy
+KUBE_MASTER="--master=https://{{ groups[master_group_name][0] }}:{{ kube_master_port }}"

--- a/roles/kubernetes/templates/config.j2
+++ b/roles/kubernetes/templates/config.j2
@@ -11,7 +11,7 @@
 #   kube-proxy.service
 
 # Comma separated list of nodes in the etcd cluster
-KUBE_ETCD_SERVERS="--etcd_servers={{ etcd_url_scheme }}://{{ groups[etcd_group_name][0] }}:{{ etcd_client_port }}"
+KUBE_ETCD_SERVERS="--etcd_servers={{ etcd_url_scheme }}://etcd.service.{{ consul_dns_domain }}:{{ etcd_client_port }}"
 
 # logging to stderr means we get it in the systemd journal
 KUBE_LOGTOSTDERR="--logtostderr=true"


### PR DESCRIPTION
After a consul cluster crash, like in one described here https://github.com/CiscoCloud/microservices-infrastructure/issues/566 , consul is unable to re-elect leader. One way to fix that is to remove consul's raft data and restart the consul service.

This is ansible playbook tasked to do that.