### PR TITLE
Consul: Restore leader after cluster crash

### DIFF
--- a/playbooks/consul-reelect-leader.yml
+++ b/playbooks/consul-reelect-leader.yml
@@ -1,0 +1,20 @@
+---
+- hosts: role=control
+  tasks:
+  - name: consul | Stop service
+    sudo: yes
+    service:
+      name: consul
+      enabled: yes
+      state: stopped
+
+  - name: fix | Remove raft database
+    sudo: yes
+    shell: rm -rf /var/lib/consul/raft/*
+
+  - name: consul | Start service
+    sudo: yes
+    service:
+      name: consul
+      enabled: yes
+      state: started


### PR DESCRIPTION
After a consul cluster crash, like in one described here #566 , consul is unable to re-elect leader. One way to fix that is to remove consul's raft data and restart the consul service.

This is ansible playbook tasked to do that.
