### PR TITLE
Add GlusterFS volume setup for floating-ip configuration

### DIFF
--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -3,6 +3,7 @@ variable datacenter { default = "openstack" }
 variable tenant_id { }
 variable tenant_name { }
 variable control_flavor_name { }
+variable glusterfs_volume_size { default = "100" } # size is in gigabytes
 variable resource_flavor_name { }
 variable keypair_name { }
 variable image_name { }
@@ -23,6 +24,16 @@ provider "openstack" {
   tenant_name	= "${ var.tenant_name }"
 }
 
+resource "openstack_blockstorage_volume_v1" "mi-control-glusterfs" {
+  name = "${ var.short_name }-control-glusterfs-${format("%02d", count.index+1) }"
+  description = "${ var.short_name }-control-glusterfs-${format("%02d", count.index+1) }"
+  size = "${ var.glusterfs_volume_size }"
+  metadata = {
+    usage = "container-volumes"
+  }
+  count = "${ var.control_count }"
+}
+
 resource "openstack_compute_instance_v2" "control" {
   floating_ip = "${ element(openstack_compute_floatingip_v2.ms-control-floatip.*.address, count.index) }"
   name                  = "${ var.short_name}-control-${format("%02d", count.index+1) }"
@@ -31,6 +42,10 @@ resource "openstack_compute_instance_v2" "control" {
   flavor_name           = "${ var.control_flavor_name }"
   security_groups       = [ "${ var.security_groups }" ]
   network               = { uuid = "${ openstack_networking_network_v2.ms-network.id }" }
+  volume = {
+    volume_id = "${element(openstack_blockstorage_volume_v1.mi-control-glusterfs.*.id, count.index)}"
+    device = "/dev/vdb"
+  }
   metadata              = {
                             dc = "${var.datacenter}"
                             role = "control"


### PR DESCRIPTION
Adding GlusterFS volume for floating-ip Terraform config, fixes https://github.com/CiscoCloud/microservices-infrastructure/issues/730.