### PR TITLE
Updated terraform.py to properly set ipv4 for inventory

### DIFF
--- a/plugins/inventory/terraform.py
+++ b/plugins/inventory/terraform.py
@@ -432,6 +432,7 @@ def vsphere_host(resource, module_name):
     attrs = {
         'id': raw_attrs['id'],
         'ip_address': raw_attrs['ip_address'],
+        'private_ipv4': raw_attrs['ip_address'],
         'metadata': parse_dict(raw_attrs, 'configuration_parameters'),
         'ansible_ssh_port': 22,
         'provider': 'vsphere',

--- a/plugins/inventory/terraform.py
+++ b/plugins/inventory/terraform.py
@@ -433,6 +433,7 @@ def vsphere_host(resource, module_name):
         'id': raw_attrs['id'],
         'ip_address': raw_attrs['ip_address'],
         'private_ipv4': raw_attrs['ip_address'],
+        'public_ipv4': raw_attrs['ip_address'],
         'metadata': parse_dict(raw_attrs, 'configuration_parameters'),
         'ansible_ssh_port': 22,
         'provider': 'vsphere',


### PR DESCRIPTION
Some of the ansible playbooks require this to be set to complete successfully.