### PR TITLE
Add support for edge nodes

### DIFF
--- a/roles/mesos/tasks/follower.yml
+++ b/roles/mesos/tasks/follower.yml
@@ -89,7 +89,7 @@
   sudo: yes
   copy:
     dest: /etc/mesos-slave/attributes
-    content: "node_id:{{ inventory_hostname }}"
+    content: "node_id:{{ inventory_hostname }};server_type:{{ role }}"
   notify: remove mesos follower metadata
   tags:
     - mesos

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -68,6 +68,23 @@
     - mesos
     - haproxy
 
+# The frontend_edge role is a special version of a worker, which offers port
+# 80 and 443 to edge/dmz servers. Firewall settings should be different from the worker
+# nodes, so that these ports are exposed to the world.
+- hosts: role=frontend_edge
+  gather_facts: no
+  vars:
+    consul_dns_domain: consul
+    mesos_mode: follower
+    # It's possible to define a separate Mesos role for the edge servers, so that
+    # only some Mesos frameworks are explicitly allowed to schedule jobs on these nodes.
+    mesos_edge_role: "*"
+    haproxy_domain: mi-lb.example.com
+    mesos_resources: "ports({{mesos_edge_role}}):[80-80, 443-443]"
+  roles:
+    - calico
+    - mesos
+
 # the control nodes are necessarily more complex than the worker nodes, and have
 # ZooKeeper, Mesos, and Marathon leaders. In addition, they control Vault to
 # manage secrets in the cluster. These servers do not run applications by

--- a/terraform/dnsimple/dns/main.tf
+++ b/terraform/dnsimple/dns/main.tf
@@ -1,7 +1,9 @@
 variable control_ips {}
 variable worker_ips {}
+variable frontend_edge_ips { default = "" }
 variable control_count {}
 variable worker_count {}
+variable frontend_edge_count { default = 0 }
 variable domain {}
 variable short_name {}
 
@@ -21,6 +23,15 @@ resource "dnsimple_record" "dns-worker" {
   value = "${element(split(\",\", var.worker_ips), count.index)}"
   type = "A"
   ttl = 60
+}
+
+resource "dnsimple_record" "dns-frontend-edge" {
+  count = "${var.frontend_edge_count}"
+  domain = "${var.domain}"
+  name = "${var.short_name}-frontend-edge-${format("%02d", count.index+1)}"
+  type = "A"
+  ttl = 60
+  value = "${element(split(\",\", var.frontend_edge_ips), count.index)}"
 }
 
 resource "dnsimple_record" "dns-worker-haproxy" {

--- a/terraform/softlayer/hosts/main.tf
+++ b/terraform/softlayer/hosts/main.tf
@@ -9,6 +9,7 @@ variable short_name { default = "mi" }
 variable ssh_key { }
 variable worker_count { default = 3 }
 variable worker_size { default = 4096 }
+variable frontend_edge_count { default = 0 }
 
 # create resources
 resource "softlayer_virtualserver" "control" {
@@ -35,10 +36,26 @@ resource "softlayer_virtualserver" "worker" {
   user_data = "{\"role\":\"worker\",\"dc\":\"${var.datacenter}\"}"
 }
 
+resource "softlayer_virtualserver" "frontend-edge" {
+  count = "${var.frontend_edge_count}"
+  name = "${var.short_name}-frontend-edge-${format("%02d", count.index+1)}"
+  domain = "${var.domain}"
+  image = "${var.image_name}"
+  region = "${var.region_name}"
+  ram = "${var.worker_size}"
+  cpu = 1
+  ssh_keys = ["${var.ssh_key}"]
+  user_data = "{\"role\":\"frontend_edge\",\"dc\":\"${var.datacenter}\"}"
+}
+
 output "control_ips" {
   value = "${join(\",\", softlayer_virtualserver.control.*.ipv4_address)}"
 }
 
 output "worker_ips" {
   value = "${join(\",\", softlayer_virtualserver.worker.*.ipv4_address)}"
+}
+
+output "frontend_edge_ips" {
+  value = "${join(\",\", softlayer_virtualserver.frontend-edge.*.ipv4_address)}"
 }


### PR DESCRIPTION
> #### Add support for edge nodes
> This creates a number of frontend edge nodes (defaults to zero)
> that are meant to run user-facing services; e.g. frontend nginx
> instances.
> 
> Initial support is for SoftLayer and OpenStack, with optional
> DNSimple records.

What do you think about this approach? I have experimented with setting up a couple of dedicated worker nodes ("frontend_edge"), meant for receiving user-facing traffic. The organisation's user-facing DNS records would point to these nodes, or to some hardware load balancer that runs directly in front of them.
The way we create, update and destroy these nodes would have to be different, since they need to be updated without downtime. I guess that can be solved with a master/standby setup, with a floating IP address; either at the Mesos task level or at an external hardware load balancer.