### PR TITLE
Update mesos consul image version to 0.3.0

### DIFF
--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -27,7 +27,7 @@ marathon_secret: ""
 
 # jobs
 mesos_consul_image: ciscocloud/mesos-consul
-mesos_consul_image_tag: v0.2.1
+mesos_consul_image_tag: v0.3
 mesos_consul_refresh: "7s"
 marathon_consul_image: ciscocloud/marathon-consul
 marathon_consul_image_tag: 0.2

--- a/roles/marathon/templates/mesos-consul.json.j2
+++ b/roles/marathon/templates/mesos-consul.json.j2
@@ -1,9 +1,9 @@
 {
   "args": [
     "--zk=zk://zookeeper.service.{{ consul_dns_domain }}:2181/mesos"{% if do_consul_ssl %},
-    "--registry-ssl",
-    "--registry-ssl-verify=false"{% endif %},
-    "--registry-token={{ consul_acl_master_token }}",
+    "--consul-ssl",
+    "--consul-ssl-verify=false"{% endif %},
+    "--consul-token={{ consul_acl_master_token }}",
     "--refresh={{ mesos_consul_refresh }}"
   ],
   "container": {


### PR DESCRIPTION
#791 

Tested on GCE, will test on AWS and DO next. 
```
[centos@lb-mi-control-01 ~]$ sudo docker images
REPOSITORY                   TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
ciscocloud/mesos-consul      v0.3                df2f1189d63c        3 hours ago         15.62 MB
```
```
[centos@lb-mi-worker-001 ~]$ sudo docker ps
CONTAINER ID        IMAGE                               COMMAND                CREATED             STATUS              PORTS                                                                      NAMES
3c7f977d57a9        ciscocloud/mesos-consul:v0.3        "/bin/mesos-consul -   5 minutes ago       Up 5 minutes       
```
```
[centos@lb-mi-worker-001 ~]$ curl localhost:8500/v1/catalog/services
{
    ...
    "mesos-consul":[

    ],
    ...
}
```