### PR TITLE
Use centos docker instead of docker inc's version

### DIFF
--- a/roles/docker/tasks/lvm.yml
+++ b/roles/docker/tasks/lvm.yml
@@ -1,11 +1,3 @@
-- name: install docker-storage-setup package
-  sudo: yes
-  yum:
-    name: "http://cbs.centos.org/kojifiles/packages/docker-storage-setup/0.5/3.el7.centos/noarch/docker-storage-setup-0.5-3.el7.centos.noarch.rpm"
-    state: present
-  tags:
-    - docker
-    - bootstrap
 
 # dependency for cloud-utils-growpart
 # which is required if we have GROWPART=yes (default) in /etc/sysconfig/docker-storage-setup
@@ -23,22 +15,5 @@
   template:
     src: docker-storage-setup.conf.j2
     dest: /etc/sysconfig/docker-storage-setup
-  tags:
-    - docker
-
-- name: setup docker storage
-  sudo: yes
-  command:  /usr/bin/docker-storage-setup
-
-# /etc/sysconfig/docker-storage created by /usr/bin/docker-storage-setup call above
-- name: create local docker service override
-  sudo: yes
-  copy:
-    dest: /etc/systemd/system/docker.service.d/storage.conf
-    content: |
-      [Service]
-      EnvironmentFile=-/etc/sysconfig/docker-storage
-  notify:
-    - restart docker
   tags:
     - docker

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -9,14 +9,6 @@
     - docker
     - bootstrap
 
-- name: install docker repo
-  sudo: yes
-  copy:
-    src: docker.repo
-    dest: /etc/yum.repos.d/docker.repo
-  tags:
-    - docker
-    - bootstrap
 
 - name: install docker packages
   sudo: yes
@@ -24,20 +16,11 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - docker-engine-1.7.0
+    - docker
     - docker-selinux
   tags:
     - docker
     - bootstrap
-
-# NOTE: this section should be before lvm.yml inclusion, because we put other configs there
-- name: create docker.system.d
-  sudo: yes
-  file:
-    dest: /etc/systemd/system/docker.service.d
-    state: directory
-  tags:
-    - docker
 
 - include: lvm.yml
   when: docker_lvm_backed_devicemapper
@@ -69,28 +52,13 @@
 - name: configure docker consul dns
   sudo: yes
   lineinfile:
-    dest: /etc/sysconfig/docker-local
-    regexp: ^other_arg=
-    line: other_arg='--dns {{ private_ipv4 }} --dns-search service.{{ consul_dns_domain }} --log-driver=syslog'
+    dest: /etc/sysconfig/docker
+    regexp: ^OPTIONS=
+    line: OPTIONS='--dns {{ private_ipv4 }} --dns-search service.{{ consul_dns_domain }} --log-driver=syslog'
     state: present
     create: yes
   notify:
     - restart docker
-  tags:
-    - docker
-
-- name: create local docker service override
-  sudo: yes
-  copy:
-    dest: /etc/systemd/system/docker.service.d/local.conf
-    content: |
-      [Service]
-      EnvironmentFile=-/etc/sysconfig/docker-local
-      ExecStart=
-      # DOCKER_STORAGE_OPTIONS defined in /etc/sysconfig/docker-storage, if it exists
-      ExecStart=/usr/bin/docker -d -H fd:// $other_arg $DOCKER_STORAGE_OPTIONS
-  notify:
-    - reload docker
   tags:
     - docker
 


### PR DESCRIPTION
Revert to using centos docker:
- remove local overrides in systemd
- use environment files in /etc/sysconfig

See #688 for the rationale for using the CentOS packages. 