### PR TITLE
Add different LVM volume sizes for control and resource nodes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ssl/serial*
 # terraform
 **/*.tfstate*
 **/.terraform
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ ssl/serial*
 # terraform
 **/*.tfstate*
 **/.terraform
-.idea/

--- a/docs/getting_started/openstack.rst
+++ b/docs/getting_started/openstack.rst
@@ -38,14 +38,14 @@ can get these variables from the OpenStack command line tools. For example:
 
 - ``glance image-list`` for ``image_name``
 - ``keystone tenant-list`` for ``tenant_id`` and ``tenant_name``
-- ``nova flavor-list`` for ``control_flavor_name`` and ``resource_flavor_name``
+- ``nova flavor-list`` for ``control_flavor_name`` and ``worker_flavor_name``
 
 Or use the appropriate OpenStack commands such as ``openstack project list`` or
 the commands below.
 
 - ``openstack image list`` for ``image_name``
 - ``openstack network list`` for ``net_id``
-- ``openstack flavor list`` for ``control_flavor_name / resource_flavor_name``
+- ``openstack flavor list`` for ``control_flavor_name / worker_flavor_name``
 
 Generate SSH keys
 ^^^^^^^^^^^^^^^^^

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -111,7 +111,7 @@ resource "aws_volume_attachment" "mi-control-nodes-lvm-attachment" {
 
 resource "aws_ebs_volume" "mi-worker-lvm" {
   availability_zone = "${var.availability_zone}"
-  count = "${var.control_count}"
+  count = "${var.worker_count}"
   size = "${var.resource_data_volume_size}"
   type = "gp2"
 

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -2,7 +2,8 @@ variable "availability_zone" {}
 variable "control_count" {default = "3"}
 variable "control_type" {default = "m1.small"}
 variable "datacenter" {default = "aws"}
-variable "data_volume_size" {default = "100"} # size is in gigabytes
+variable "control_data_volume_size" {default = "20"} # size is in gigabytes
+variable "resource_data_volume_size" {default = "100"} # size is in gigabytes
 variable "long_name" {default = "microservices-infastructure"}
 variable "network_ipv4" {default = "10.0.0.0/16"}
 variable "network_subnet_ip4" {default = "10.0.0.0/16"}
@@ -62,7 +63,7 @@ resource "aws_main_route_table_association" "main" {
 resource "aws_ebs_volume" "mi-control-lvm" {
   availability_zone = "${var.availability_zone}"
   count = "${var.control_count}"
-  size = "${var.data_volume_size}"
+  size = "${var.control_data_volume_size}"
   type = "gp2"
 
   tags {
@@ -111,7 +112,7 @@ resource "aws_volume_attachment" "mi-control-nodes-lvm-attachment" {
 resource "aws_ebs_volume" "mi-worker-lvm" {
   availability_zone = "${var.availability_zone}"
   count = "${var.control_count}"
-  size = "${var.data_volume_size}"
+  size = "${var.resource_data_volume_size}"
   type = "gp2"
 
   tags {

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -3,7 +3,7 @@ variable "control_count" {default = "3"}
 variable "control_type" {default = "m1.small"}
 variable "datacenter" {default = "aws"}
 variable "control_data_volume_size" {default = "20"} # size is in gigabytes
-variable "resource_data_volume_size" {default = "100"} # size is in gigabytes
+variable "worker_data_volume_size" {default = "100"} # size is in gigabytes
 variable "long_name" {default = "microservices-infastructure"}
 variable "network_ipv4" {default = "10.0.0.0/16"}
 variable "network_subnet_ip4" {default = "10.0.0.0/16"}
@@ -112,7 +112,7 @@ resource "aws_volume_attachment" "mi-control-nodes-lvm-attachment" {
 resource "aws_ebs_volume" "mi-worker-lvm" {
   availability_zone = "${var.availability_zone}"
   count = "${var.worker_count}"
-  size = "${var.resource_data_volume_size}"
+  size = "${var.worker_data_volume_size}"
   type = "gp2"
 
   tags {
@@ -152,7 +152,7 @@ resource "aws_instance" "mi-worker-nodes" {
 }
 
 resource "aws_volume_attachment" "mi-worker-nodes-lvm-attachment" {
-  count = "${var.control_count}"
+  count = "${var.worker_count}"
   device_name = "xvdh"
   instance_id = "${element(aws_instance.mi-worker-nodes.*.id, count.index)}"
   volume_id = "${element(aws_ebs_volume.mi-worker-lvm.*.id, count.index)}"

--- a/terraform/gce/gce.tf
+++ b/terraform/gce/gce.tf
@@ -12,7 +12,7 @@ variable "ssh_user" {default = "centos"}
 variable "worker_count" {default = 1}
 variable "worker_type" {default = "n1-highcpu-2"}
 variable "control_volume_size" {default = "20"} # size is in gigabytes
-variable "worker_volume_size" {default = "20"} # size is in gigabytes
+variable "worker_volume_size" {default = "100"} # size is in gigabytes
 
 # Network
 resource "google_compute_network" "mi-network" {

--- a/terraform/gce/gce.tf
+++ b/terraform/gce/gce.tf
@@ -1,7 +1,8 @@
 variable "control_count" {default = 3}
 variable "control_type" {default = "n1-standard-1"}
 variable "datacenter" {default = "gce"}
-variable "data_volume_size" {default = "100"} # size is in gigabytes
+variable "control_data_volume_size" {default = "20"} # size is in gigabytes
+variable "worker_data_volume_size" {default = "100"} # size is in gigabytes
 variable "long_name" {default = "microservices-infastructure"}
 variable "network_ipv4" {default = "10.0.0.0/16"}
 variable "region" {default = "us-central1"}
@@ -67,7 +68,7 @@ resource "google_compute_disk" "mi-control-lvm" {
   name = "${var.short_name}-control-lvm-${format("%02d", count.index+1)}"
   type = "pd-ssd"
   zone = "${var.zone}"
-  size = "${var.data_volume_size}"
+  size = "${var.control_data_volume_size}"
 
   count = "${var.control_count}"
 }
@@ -76,7 +77,7 @@ resource "google_compute_disk" "mi-worker-lvm" {
   name = "${var.short_name}-worker-lvm-${format("%02d", count.index+1)}"
   type = "pd-ssd"
   zone = "${var.zone}"
-  size = "${var.data_volume_size}"
+  size = "${var.worker_data_volume_size}"
 
   count = "${var.control_count}"
 }

--- a/terraform/gce/gce.tf
+++ b/terraform/gce/gce.tf
@@ -79,7 +79,7 @@ resource "google_compute_disk" "mi-worker-lvm" {
   zone = "${var.zone}"
   size = "${var.worker_data_volume_size}"
 
-  count = "${var.control_count}"
+  count = "${var.worker_count}"
 }
 
 resource "google_compute_instance" "mi-control-nodes" {

--- a/terraform/openstack-floating.sample.tf
+++ b/terraform/openstack-floating.sample.tf
@@ -14,13 +14,13 @@ module "dc2-hosts-floating" {
         tenant_id = ""
         tenant_name = ""
         control_flavor_name = ""
-        resource_flavor_name  = ""
+        worker_flavor_name  = ""
         image_name = ""
         keypair_name = "${ module.dc2-keypair.keypair_name }"
         control_count = 3
-        resource_count = 3
+        worker_count = 3
         control_data_volume_size = 20
-        resource_data_volume_size = 100
+        worker_data_volume_size = 100
 	    floating_pool = ""
 	    external_net_id = ""
 }

--- a/terraform/openstack-floating.sample.tf
+++ b/terraform/openstack-floating.sample.tf
@@ -19,8 +19,10 @@ module "dc2-hosts-floating" {
         keypair_name = "${ module.dc2-keypair.keypair_name }"
         control_count = 3
         resource_count = 3
-	floating_pool = ""
-	external_net_id = ""
+        control_data_volume_size = 20
+        resource_data_volume_size = 100
+	    floating_pool = ""
+	    external_net_id = ""
 }
 
 # Example setup for DNS:

--- a/terraform/openstack.sample.tf
+++ b/terraform/openstack.sample.tf
@@ -14,15 +14,15 @@ module "dc2-hosts" {
   tenant_id = ""
   tenant_name = ""
   control_flavor_name = ""
-  resource_flavor_name  = ""
+  worker_flavor_name  = ""
   net_id = ""
   image_name = ""
   keypair_name = "${ module.dc2-keypair.keypair_name }"
   control_count = 3
-  resource_count = 3
+  worker_count = 3
   security_groups = ""
   control_data_volume_size = 20
-  resource_data_volume_size = 100
+  worker_data_volume_size = 100
 }
 
 # Example setup for DNS:

--- a/terraform/openstack.sample.tf
+++ b/terraform/openstack.sample.tf
@@ -21,7 +21,8 @@ module "dc2-hosts" {
   control_count = 3
   resource_count = 3
   security_groups = ""
-  data_volume_size = 100
+  control_data_volume_size = 20
+  resource_data_volume_size = 100
 }
 
 # Example setup for DNS:

--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -3,7 +3,8 @@ variable datacenter { default = "openstack" }
 variable tenant_id { }
 variable tenant_name { }
 variable control_flavor_name { }
-variable data_volume_size { default = "100" } # size is in gigabytes
+variable control_data_volume_size { default = "20" } # size is in gigabytes
+variable resource_data_volume_size { default = "100" } # size is in gigabytes
 variable resource_flavor_name { }
 variable keypair_name { }
 variable image_name { }
@@ -27,7 +28,7 @@ provider "openstack" {
 resource "openstack_blockstorage_volume_v1" "mi-control-lvm" {
   name = "${ var.short_name }-control-lvm-${format("%02d", count.index+1) }"
   description = "${ var.short_name }-control-lvm-${format("%02d", count.index+1) }"
-  size = "${ var.data_volume_size }"
+  size = "${ var.control_data_volume_size }"
   metadata = {
     usage = "container-volumes"
   }
@@ -37,7 +38,7 @@ resource "openstack_blockstorage_volume_v1" "mi-control-lvm" {
 resource "openstack_blockstorage_volume_v1" "mi-resource-lvm" {
   name = "${ var.short_name }-control-lvm-${format("%02d", count.index+1) }"
   description = "${ var.short_name }-control-lvm-${format("%02d", count.index+1) }"
-  size = "${ var.data_volume_size }"
+  size = "${ var.resources_data_volume_size }"
   metadata = {
     usage = "container-volumes"
   }

--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -4,12 +4,12 @@ variable tenant_id { }
 variable tenant_name { }
 variable control_flavor_name { }
 variable control_data_volume_size { default = "20" } # size is in gigabytes
-variable resource_data_volume_size { default = "100" } # size is in gigabytes
-variable resource_flavor_name { }
+variable worker_data_volume_size { default = "100" } # size is in gigabytes
+variable worker_flavor_name { }
 variable keypair_name { }
 variable image_name { }
 variable control_count {}
-variable resource_count {}
+variable worker_count {}
 variable security_groups { default = "default" }
 variable floating_pool {}
 variable external_net_id { }
@@ -35,14 +35,14 @@ resource "openstack_blockstorage_volume_v1" "mi-control-lvm" {
   count = "${ var.control_count }"
 }
 
-resource "openstack_blockstorage_volume_v1" "mi-resource-lvm" {
-  name = "${ var.short_name }-control-lvm-${format("%02d", count.index+1) }"
-  description = "${ var.short_name }-control-lvm-${format("%02d", count.index+1) }"
-  size = "${ var.resources_data_volume_size }"
+resource "openstack_blockstorage_volume_v1" "mi-worker-lvm" {
+  name = "${ var.short_name }-worker-lvm-${format("%02d", count.index+1) }"
+  description = "${ var.short_name }-worker-lvm-${format("%02d", count.index+1) }"
+  size = "${ var.worker_data_volume_size }"
   metadata = {
     usage = "container-volumes"
   }
-  count = "${ var.resource_count }"
+  count = "${ var.worker_count }"
 }
 
 resource "openstack_compute_instance_v2" "control" {
@@ -65,16 +65,16 @@ resource "openstack_compute_instance_v2" "control" {
   count                 = "${ var.control_count }"
 }
 
-resource "openstack_compute_instance_v2" "resource" {
-  floating_ip = "${ element(openstack_compute_floatingip_v2.ms-resource-floatip.*.address, count.index) }"
+resource "openstack_compute_instance_v2" "worker" {
+  floating_ip = "${ element(openstack_compute_floatingip_v2.ms-worker-floatip.*.address, count.index) }"
   name                  = "${ var.short_name}-worker-${format("%03d", count.index+1) }"
   key_pair              = "${ var.keypair_name }"
   image_name            = "${ var.image_name }"
-  flavor_name           = "${ var.resource_flavor_name }"
+  flavor_name           = "${ var.worker_flavor_name }"
   security_groups       = [ "${ var.security_groups }" ]
   network               = { uuid = "${ openstack_networking_network_v2.ms-network.id }" }
   volume = {
-    volume_id = "${element(openstack_blockstorage_volume_v1.mi-resource-lvm.*.id, count.index)}"
+    volume_id = "${element(openstack_blockstorage_volume_v1.mi-worker-lvm.*.id, count.index)}"
     device = "/dev/vdb"
   }
   metadata              = {
@@ -82,7 +82,7 @@ resource "openstack_compute_instance_v2" "resource" {
                             role = "worker"
                             ssh_user = "${ var.ssh_user }"
                           }
-  count                 = "${ var.resource_count }"
+  count                 = "${ var.worker_count }"
 }
 
 resource "openstack_compute_floatingip_v2" "ms-control-floatip" {
@@ -93,9 +93,9 @@ resource "openstack_compute_floatingip_v2" "ms-control-floatip" {
                  "openstack_networking_router_interface_v2.ms-router-interface" ]
 }
 
-resource "openstack_compute_floatingip_v2" "ms-resource-floatip" {
+resource "openstack_compute_floatingip_v2" "ms-worker-floatip" {
   pool       = "${ var.floating_pool }"
-  count      = "${ var.resource_count }"
+  count      = "${ var.worker_count }"
   depends_on = [ "openstack_networking_router_v2.ms-router",
                  "openstack_networking_network_v2.ms-network",
                  "openstack_networking_router_interface_v2.ms-router-interface" ]
@@ -127,5 +127,5 @@ output "control_ips" {
 }
 
 output "worker_ips" {
-  value = "${join(\",\", openstack_compute_instance_v2.resource.*.access_ip_v4)}"
+  value = "${join(\",\", openstack_compute_instance_v2.worker.*.access_ip_v4)}"
 }

--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -2,7 +2,8 @@ variable auth_url { }
 variable control_count {}
 variable control_flavor_name { }
 variable datacenter { default = "openstack" }
-variable data_volume_size { default = "100" } # size is in gigabytes
+variable control_data_volume_size { default = "20" } # size is in gigabytes
+variable resource_data_volume_size { default = "100" } # size is in gigabytes
 variable image_name { }
 variable keypair_name { }
 variable long_name { default = "microservices-infrastructure" }
@@ -24,7 +25,7 @@ provider "openstack" {
 resource "openstack_blockstorage_volume_v1" "mi-control-lvm" {
   name = "${ var.short_name }-control-lvm-${format("%02d", count.index+1) }"
   description = "${ var.short_name }-control-lvm-${format("%02d", count.index+1) }"
-  size = "${ var.data_volume_size }"
+  size = "${ var.control_data_volume_size }"
   metadata = {
     usage = "container-volumes"
   }
@@ -34,7 +35,7 @@ resource "openstack_blockstorage_volume_v1" "mi-control-lvm" {
 resource "openstack_blockstorage_volume_v1" "mi-resource-lvm" {
   name = "${ var.short_name }-resource-lvm-${format("%02d", count.index+1) }"
   description = "${ var.short_name }-resource-lvm-${format("%02d", count.index+1) }"
-  size = "${ var.data_volume_size }"
+  size = "${ var.resource_data_volume_size }"
   metadata = {
     usage = "container-volumes"
   }

--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -39,7 +39,7 @@ resource "openstack_blockstorage_volume_v1" "mi-resource-lvm" {
   metadata = {
     usage = "container-volumes"
   }
-  count = "${ var.control_count }"
+  count = "${ var.resource_count }"
 }
 
 resource "openstack_compute_instance_v2" "control" {


### PR DESCRIPTION
100GB volumes don't look quite reasonable for control nodes.
Added appropriate options to Terraform files.