### PR TITLE
Add support for 5s of stale DNS reads in Consul

### DIFF
--- a/roles/consul/defaults/main.yml
+++ b/roles/consul/defaults/main.yml
@@ -17,3 +17,5 @@ consul_acl_down_policy: "allow"
 consul_dns_domain: consul
 consul_verify_incoming: true
 consul_verify_outgoing: true
+consul_allow_stale: true
+consul_max_stale: 5s

--- a/roles/consul/templates/consul.json.j2
+++ b/roles/consul/templates/consul.json.j2
@@ -25,5 +25,9 @@
   "disable_remote_exec": {{ consul_disable_remote_exec|to_nice_json }},
   "http_api_response_headers": {
     "Access-Control-Allow-Origin": "*"
+  },
+  "dns_config": {
+    "allow_stale": {{ consul_allow_stale|to_nice_json }},
+    "max_stale": "{{ consul_max_stale }}"
   }
 }


### PR DESCRIPTION
Fixes #667

Tested on GCE

```
[root@lb-mi-control-01 consul]# cat consul.json
{
  "datacenter": "lb-gce-dc",
  "advertise_addr": "10.0.0.2",
  "node_name": "lb-mi-control-01",
  "rejoin_after_leave": true,
  "domain": "consul",
  "retry_join": [ "10.0.0.4", "10.0.0.2", "10.0.0.5" ],
  "server": true,
  "bootstrap_expect": 3,
  "encrypt": "gvw3HlRllZDcClmukVn6sQ==",
  "ca_file": "/etc/consul/ssl/ca.cert",
  "cert_file": "/etc/consul/ssl/consul.cert",
  "key_file": "/etc/consul/ssl/consul.key",
  "verify_incoming": true,
  "verify_outgoing": true,
  "data_dir": "/var/lib/consul",
  "ui_dir": "/usr/share/consul-ui",
  "enable_syslog": true,
  "disable_remote_exec": true,
  "http_api_response_headers": {
    "Access-Control-Allow-Origin": "*"
  },
  "dns_config": {
    "allow_stale": true,
    "max_stale": "5s"
  }
}
[root@lb-mi-control-01 consul]# systemctl status consul
consul.service - Consul is a tool for service discovery and configuration. Consul is distributed, highly available, and extremely scalable.
   Loaded: loaded (/usr/lib/systemd/system/consul.service; enabled)
   Active: active (running) since Wed 2015-11-11 20:03:58 UTC; 15min ago
```