### PR TITLE
mantlui: bump to 0.3

### DIFF
--- a/roles/mantlui/defaults/main.yml
+++ b/roles/mantlui/defaults/main.yml
@@ -1,4 +1,4 @@
 mantlui_nginx_image: ciscocloud/nginx-mantlui
-mantlui_nginx_image_tag: 0.2
+mantlui_nginx_image_tag: 0.3
 do_mantlui_ssl: false
 do_mantlui_auth: false


### PR DESCRIPTION
Update to Mantl UI 0.3, which is a major visual update and lays the groundwork for future improvements to the management interface.

The new repo for the frontend components of the UI is at https://github.com/CiscoCloud/mantl-ui-frontend

And it looks like this:

![new UI](https://github.com/CiscoCloud/mantl-ui-frontend/raw/master/screenshot.png)