### PR TITLE
mantl-api installed by default

### DIFF
--- a/roles/logstash/templates/logstash-service.j2
+++ b/roles/logstash/templates/logstash-service.j2
@@ -21,7 +21,7 @@ ExecStart=/usr/bin/docker run \
     --publish=1514:1514 \
     --publish=25826:25826/udp \
     --publish=8125:8125/udp \
-{% if role == 'control' %}
+{% if "'role=control' in group_names" %}
     --publish=5678:5678/tcp \
 {% endif %}
 {% if logstash_input_log4j %}
@@ -30,10 +30,10 @@ ExecStart=/usr/bin/docker run \
     --volume=/etc/logstash.d:/config-dir \
     --volume=/var/lib/docker/containers:/logs/docker:ro \
     --volume=/var/log/mesos:/logs/mesos:ro \
-{% if role == 'worker' %}
+{% if "'role=worker' in group_names" %}
     --volume=/tmp/mesos/slaves:/logs/slaves:ro \
 {% endif %}
-{% if role == 'control' %}
+{% if "'role=control' in group_names" %}
     --volume=/var/log/zookeeper:/logs/zookeeper:ro \
 {% endif %}
     --volume=/usr/share/collectd:/collectd:ro \

--- a/roles/logstash/templates/logstash.conf.j2
+++ b/roles/logstash/templates/logstash.conf.j2
@@ -1,5 +1,5 @@
 input {
-{% if role == 'control' %}
+{% if "'role=control' in group_names" %}
   file {
     path => [ "/logs/mesos/*.INFO", "/logs/mesos/*.WARNING", "/logs/mesos/*.ERROR", "/logs/mesos/*.FATAL" ]
     type => "mesos-master-logs"
@@ -14,7 +14,7 @@ input {
     type => zookeeper
   }
 {% endif %}
-{% if role == 'worker' %}
+{% if "'role=worker' in group_names" %}
   file {
     path => [ "/logs/mesos/*.INFO", "/logs/mesos/*.WARNING", "/logs/mesos/*.ERROR", "/logs/mesos/*.FATAL" ]
     type => "mesos-slave-logs"

--- a/roles/mantlui/templates/mantlui.nginx.j2
+++ b/roles/mantlui/templates/mantlui.nginx.j2
@@ -36,6 +36,11 @@ http {
     {% raw -%}{{$consulproto := "http"}}{%- endraw %}
     {%- endif %}
 
+    {% raw %}{{$mantlapi := service "mantl-api"}}{{with $mantlapi}}
+    upstream mantlapi { {{range $mantlapi}}
+        server {{.Address}}:{{.Port}};{{end}}
+    } {{end}}{% endraw %}
+
 {% if do_mantlui_ssl|bool %}
     server {
         listen 80;
@@ -122,5 +127,14 @@ http {
             index index.html index.htm;
             try_files $uri $uri/ =404;
         }
+
+        {% raw %}{{with $mantlapi}}
+        location /api/ {
+            proxy_set_header        host $host;
+            proxy_set_header        x-real-ip $remote_addr;
+            proxy_set_header        x-forwarded-for $proxy_add_x_forwarded_for;
+            proxy_set_header        x-forwarded-proto $scheme;
+            proxy_pass http://mantlapi/;
+        } {{end}}{% endraw %}
     }
 }

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -31,4 +31,5 @@ mesos_consul_image_tag: v0.3
 mesos_consul_refresh: "7s"
 marathon_consul_image: ciscocloud/marathon-consul
 marathon_consul_image_tag: 0.2
-
+mantl_api_image: ciscocloud/mantl-api
+mantl_api_image_tag: 0.1.0

--- a/roles/marathon/tasks/jobs.yml
+++ b/roles/marathon/tasks/jobs.yml
@@ -5,6 +5,7 @@
   with_items:
     - "{{ mesos_consul_image }}:{{ mesos_consul_image_tag }}"
     - "{{ marathon_consul_image }}:{{ marathon_consul_image_tag }}"
+    - "{{ mantl_api_image }}:{{ mantl_api_image_tag }}"
   tags:
     - marathon
     - bootstrap
@@ -17,6 +18,7 @@
   with_items:
     - mesos-consul
     - marathon-consul
+    - mantl-api
   tags:
     - marathon
 
@@ -25,9 +27,12 @@
   sudo: yes
   command: 'curl -X PUT -d@/etc/marathon/{{ item }}.json -H "Content-Type: application/json" http://localhost:18080/v2/apps/{{ item }}'
   changed_when: false
+  failed_when: "'deploymentId' not in result.stdout"
+  register: result
   with_items:
     - mesos-consul
     - marathon-consul
+    - mantl-api
   tags:
     - marathon
 

--- a/roles/marathon/templates/mantl-api.json.j2
+++ b/roles/marathon/templates/mantl-api.json.j2
@@ -1,0 +1,39 @@
+{
+  "id": "mantl-api",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{ mantl_api_image }}:{{ mantl_api_image_tag }}",
+      "network": "BRIDGE",
+      "portMappings": [
+        { "containerPort": 4001, "hostPort": 0, "protocol": "tcp" }
+      ],
+      "forcePullImage": true
+    }
+  },
+  "instances": 1,
+  "cpus": 0.1,
+  "mem": 128,
+  "env": { {% if do_consul_ssl %}
+    "CONSUL_HTTP_SSL_VERIFY": "false",{% endif %}
+    "MANTL_API_LOG_LEVEL": "debug",
+    "MANTL_API_CONSUL": "{% if do_consul_ssl %}https{% else %}http{% endif %}://consul.service.{{ consul_dns_domain }}:8500",
+    "MANTL_API_MARATHON": "{% if do_marathon_ssl %}https{% else %}http{% endif %}://marathon.service.consul:8080"{% if do_marathon_auth %},
+    "MANTL_API_MARATHON_USER": "{{ marathon_http_credentials.split(':')[0] }}",
+    "MANTL_API_MARATHON_PASSWORD": "{{ marathon_http_credentials.split(':')[1] }}"{% endif %}{% if do_marathon_ssl %},
+    "MANTL_API_MARATHON_NO_VERIFY_SSL": "true"{% endif %}{% if do_mesos_auth %},
+    "MANTL_API_MESOS_PRINCIPAL": "{{ mantl_api_principal }}",
+    "MANTL_API_MESOS_SECRET": "{{ mantl_api_secret }}"{% endif %}
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/health",
+      "gracePeriodSeconds": 5,
+      "intervalSeconds": 10,
+      "portIndex": 0,
+      "timeoutSeconds": 10,
+      "maxConsecutiveFailures": 5
+    }
+  ]
+}

--- a/roles/mesos/tasks/follower.yml
+++ b/roles/mesos/tasks/follower.yml
@@ -67,6 +67,25 @@
   tags:
     - mesos
 
+- name: write mantl-api credential
+  when: do_mesos_framework_auth|bool
+  sudo: yes
+  template:
+    src: mantl-api-credential.j2
+    dest: /etc/mesos/mantl-api
+    mode: 0600
+  tags:
+    - mesos
+
+- name: delete mantl-api credential
+  when: not do_mesos_framework_auth|bool
+  sudo: yes
+  file:
+    dest: /etc/mesos/mantl-api
+    state: absent
+  tags:
+    - mesos
+
 - name: set executor registration timeout
   sudo: yes
   copy:

--- a/roles/mesos/templates/mantl-api-credential.j2
+++ b/roles/mesos/templates/mantl-api-credential.j2
@@ -1,0 +1,1 @@
+{{ mantl_api_secret }}


### PR DESCRIPTION
mantl-api integration. It is accessible at /api on control nodes.

This also includes a fix for the logstash role that had broken the vagrant build (#782)