### PR TITLE
mantl-api: bump version

### DIFF
--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -32,4 +32,4 @@ mesos_consul_refresh: "7s"
 marathon_consul_image: ciscocloud/marathon-consul
 marathon_consul_image_tag: 0.2
 mantl_api_image: ciscocloud/mantl-api
-mantl_api_image_tag: 0.1.0
+mantl_api_image_tag: 0.1.1


### PR DESCRIPTION
0.1.1 enables custom packages (packages that don't exist in the mesosphere universe)