### PR TITLE
Removing ansible roles that are superseded by consul-rpm (PR#1)

### DIFF
--- a/roles/common/files/10-root-nofiles.conf
+++ b/roles/common/files/10-root-nofiles.conf
@@ -1,2 +1,0 @@
-root hard nofiles 65000
-root soft nofiles 65000

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -70,19 +70,5 @@
   tags:
     - distributive
 
-- name: increase ulimit for root
-  sudo: yes
-  copy:
-    dest: /etc/security/limits.d/10-root-nofiles.conf
-    src: 10-root-nofiles.conf
-
-- name: sysctl max file limit
-  sudo: yes
-  sysctl:
-    name: fs.file-max
-    value: 65000
-    sysctl_set: true
-    reload: yes
-
 - include: users.yml
 - include: ssl.yml

--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: install consul
   sudo: yes
   yum:
-    name: "https://bintray.com/artifact/download/ciscocloud/rpm/consul-0.5.2-2.el7.centos.x86_64.rpm"
+    name: "https://bintray.com/artifact/download/ciscocloud/rpm/consul-0.5.2-3.el7.centos.x86_64.rpm"
     state: present
   tags:
     - consul
@@ -11,7 +11,7 @@
 - name: install consul-ui
   sudo: yes
   yum:
-    name: "https://bintray.com/artifact/download/ciscocloud/rpm/consul-ui-0.5.2-2.el7.centos.x86_64.rpm"
+    name: "https://bintray.com/artifact/download/ciscocloud/rpm/consul-ui-0.5.2-3.el7.centos.x86_64.rpm"
     state: present
   when: consul_is_server
   tags:


### PR DESCRIPTION
This removes ansible roles that are superseded by my PR in ciscocloud/consul-rpm#1. This code was broken on older versions of ansible, so that will also fix #814 