### PR TITLE
mantlui: update to 0.5

### DIFF
--- a/roles/mantlui/defaults/main.yml
+++ b/roles/mantlui/defaults/main.yml
@@ -1,4 +1,4 @@
 mantlui_nginx_image: ciscocloud/nginx-mantlui
-mantlui_nginx_image_tag: 0.4
+mantlui_nginx_image_tag: 0.5
 do_mantlui_ssl: false
 do_mantlui_auth: false


### PR DESCRIPTION
Fixes a few bugs that I've noticed while preparing (Mantl) 0.5. Namely:

- healthchecks wouldn't update while focused on a single healthcheck. Now they do.
- clicking the health status of a service would take you to the overall health page. Now it takes you to the specific health checks of the service you clicked on.

It also adds logos for Traefik when we are able to add that to the UI.