### PR TITLE
Add docker group for correct docker socket permissions

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -9,6 +9,14 @@
     - docker
     - bootstrap
 
+- name: add docker group
+  sudo: yes
+  group:
+    name: docker
+    state: present
+  tags:
+    - docker
+    - bootstrap
 
 - name: install docker packages
   sudo: yes


### PR DESCRIPTION
This is needed for Cadvisor to be able to connect to Docker socket correctly.
Worked for us in DCOS deployments for a long time.