### PR TITLE
Add support for Infoblox DNS Provider

### DIFF
--- a/terraform/infoblox/dns/main.tf
+++ b/terraform/infoblox/dns/main.tf
@@ -1,0 +1,36 @@
+variable control_ips {}
+variable edge_ips {}
+variable worker_ips {}
+variable control_count {}
+variable edge_count {}
+variable worker_count {}
+variable domain {}
+variable short_name {}
+
+resource "infoblox_record" "dns-control" {
+  count = "${var.control_count}"
+  domain = "${var.domain}"
+  ipv4addr = "${element(split(\",\", var.control_ips), count.index)}"
+  name = "${var.short_name}-control-${format("%02d", count.index+1)}"
+}
+
+resource "infoblox_record" "dns-worker" {
+  count = "${var.worker_count}"
+  domain = "${var.domain}"
+  name = "${var.short_name}-worker-${format("%03d", count.index+1)}"
+  ipv4addr = "${element(split(\",\", var.worker_ips), count.index)}"
+}
+
+resource "infoblox_record" "dns-edge" {
+  count = "${var.edge_count}"
+  domain = "${var.domain}"
+  name = "${var.short_name}-edge-${format("%03d", count.index+1)}"
+  ipv4addr = "${element(split(\",\", var.edge_ips), count.index)}"
+}
+
+resource "infoblox_record" "dns-worker-haproxy" {
+  count = "${var.worker_count}"
+  domain = "${var.domain}"
+  name = "*.${var.short_name}-lb"
+  ipv4addr = "${element(split(\",\", var.worker_ips), count.index)}"
+}

--- a/terraform/infoblox/dns/main.tf
+++ b/terraform/infoblox/dns/main.tf
@@ -10,27 +10,35 @@ variable short_name {}
 resource "infoblox_record" "dns-control" {
   count = "${var.control_count}"
   domain = "${var.domain}"
-  ipv4addr = "${element(split(\",\", var.control_ips), count.index)}"
+  value = "${element(split(\",\", var.control_ips), count.index)}"
   name = "${var.short_name}-control-${format("%02d", count.index+1)}"
+  type = "A"
+  ttl = "60"
 }
 
 resource "infoblox_record" "dns-worker" {
   count = "${var.worker_count}"
   domain = "${var.domain}"
   name = "${var.short_name}-worker-${format("%03d", count.index+1)}"
-  ipv4addr = "${element(split(\",\", var.worker_ips), count.index)}"
+  value = "${element(split(\",\", var.worker_ips), count.index)}"
+  type = "A"
+  ttl = "60"
 }
 
 resource "infoblox_record" "dns-edge" {
   count = "${var.edge_count}"
   domain = "${var.domain}"
   name = "${var.short_name}-edge-${format("%03d", count.index+1)}"
-  ipv4addr = "${element(split(\",\", var.edge_ips), count.index)}"
+  value = "${element(split(\",\", var.edge_ips), count.index)}"
+  type = "A"
+  ttl = "60"
 }
 
 resource "infoblox_record" "dns-worker-haproxy" {
   count = "${var.worker_count}"
   domain = "${var.domain}"
   name = "*.${var.short_name}-lb"
-  ipv4addr = "${element(split(\",\", var.worker_ips), count.index)}"
+  value = "${element(split(\",\", var.worker_ips), count.index)}"
+  type = "A"
+  ttl = "60"
 }

--- a/terraform/infoblox/dns/main.tf
+++ b/terraform/infoblox/dns/main.tf
@@ -1,44 +1,58 @@
-variable control_ips {}
-variable edge_ips {}
-variable worker_ips {}
+# input variables
 variable control_count {}
-variable edge_count {}
-variable worker_count {}
+variable control_ips {}
+variable control_subdomain { default = "control" }
 variable domain {}
+variable edge_count {}
+variable edge_ips {}
 variable short_name {}
+variable subdomain { default = "" }
+variable worker_count {}
+variable worker_ips {}
 
+# individual records
 resource "infoblox_record" "dns-control" {
   count = "${var.control_count}"
   domain = "${var.domain}"
-  value = "${element(split(\",\", var.control_ips), count.index)}"
-  name = "${var.short_name}-control-${format("%02d", count.index+1)}"
+  value = "${element(split(",", var.control_ips), count.index)}"
+  name = "${var.short_name}-control-${format("%02d", count.index+1)}.node${var.subdomain}"
   type = "A"
-  ttl = "60"
-}
-
-resource "infoblox_record" "dns-worker" {
-  count = "${var.worker_count}"
-  domain = "${var.domain}"
-  name = "${var.short_name}-worker-${format("%03d", count.index+1)}"
-  value = "${element(split(\",\", var.worker_ips), count.index)}"
-  type = "A"
-  ttl = "60"
+  ttl = 60
 }
 
 resource "infoblox_record" "dns-edge" {
   count = "${var.edge_count}"
   domain = "${var.domain}"
-  name = "${var.short_name}-edge-${format("%03d", count.index+1)}"
-  value = "${element(split(\",\", var.edge_ips), count.index)}"
+  value = "${element(split(",", var.edge_ips), count.index)}"
+  name = "${var.short_name}-edge-${format("%02d", count.index+1)}.node${var.subdomain}"
   type = "A"
-  ttl = "60"
+  ttl = 60
 }
 
-resource "infoblox_record" "dns-worker-haproxy" {
+resource "infoblox_record" "dns-worker" {
   count = "${var.worker_count}"
   domain = "${var.domain}"
-  name = "*.${var.short_name}-lb"
-  value = "${element(split(\",\", var.worker_ips), count.index)}"
+  value = "${element(split(",", var.worker_ips), count.index)}"
+  name = "${var.short_name}-worker-${format("%03d", count.index+1)}.node${var.subdomain}"
   type = "A"
-  ttl = "60"
+  ttl = 60
+}
+
+# group records
+resource "infoblox_record" "dns-control-group" {
+  count = "${var.control_count}"
+  domain = "${var.domain}"
+  value = "${element(split(",", var.control_ips), count.index)}"
+  name = "${var.control_subdomain}${var.subdomain}"
+  type = "A"
+  ttl = 60
+}
+
+resource "infoblox_record" "dns-wildcard" {
+  count = "${var.edge_count}"
+  domain = "${var.domain}"
+  value = "${element(split(",", var.edge_ips), count.index)}"
+  name = "*${var.subdomain}"
+  type = "A"
+  ttl = 60
 }


### PR DESCRIPTION
This PR adds support for Infoblox DNS provider. This provider is still in the process of being merged to Terraform's master branch. https://github.com/hashicorp/terraform/pull/4006