### PR TITLE
make vsphere pool variable optional

### DIFF
--- a/terraform/vsphere/main.tf
+++ b/terraform/vsphere/main.tf
@@ -1,6 +1,6 @@
 variable "datacenter" {}
 variable "host" {}
-variable "pool" {}
+variable "pool" {default = ""}
 variable "template" {}
 variable "ssh_user" {}
 variable "ssh_key" {}


### PR DESCRIPTION
Some people might not have the license to enable DRS that is required to create resource pools. So, make pool an optional variable.