### PR TITLE
Attach volumes to /dev/vdc by default

### DIFF
--- a/roles/lvm/defaults/main.yml
+++ b/roles/lvm/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 lvm_volume_group_name: mantl
-lvm_physical_device: "{% if provider == 'gce' %}/dev/disk/by-id/google-lvm{% elif provider == 'aws' %}/dev/xvdh{% elif provider == 'openstack' %}/dev/vdb{% endif %}"
+lvm_physical_device: "{% if provider == 'gce' %}/dev/disk/by-id/google-lvm{% elif provider == 'aws' %}/dev/xvdh{% elif provider == 'openstack' %}/dev/vdc{% endif %}"

--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -68,7 +68,7 @@ resource "openstack_compute_instance_v2" "control" {
   network               = { uuid = "${ openstack_networking_network_v2.ms-network.id }" }
   volume = {
     volume_id = "${element(openstack_blockstorage_volume_v1.mi-control-lvm.*.id, count.index)}"
-    device = "/dev/vdb"
+    device = "/dev/vdc"
   }
   metadata              = {
                             dc = "${var.datacenter}"
@@ -88,7 +88,7 @@ resource "openstack_compute_instance_v2" "worker" {
   network               = { uuid = "${ openstack_networking_network_v2.ms-network.id }" }
   volume = {
     volume_id = "${element(openstack_blockstorage_volume_v1.mi-worker-lvm.*.id, count.index)}"
-    device = "/dev/vdb"
+    device = "/dev/vdc"
   }
   metadata              = {
                             dc = "${var.datacenter}"
@@ -109,7 +109,7 @@ resource "openstack_compute_instance_v2" "edge" {
 
   volume = {
     volume_id = "${element(openstack_blockstorage_volume_v1.mi-edge-lvm.*.id, count.index)}"
-    device = "/dev/vdb"
+    device = "/dev/vdc"
   }
 
   metadata = {


### PR DESCRIPTION
Some openstack flavours already have volumes attached to /dev/vdb by default