### PR TITLE
Add ami region mapping to sample file

### DIFF
--- a/terraform/aws.sample.tf
+++ b/terraform/aws.sample.tf
@@ -1,14 +1,16 @@
+variable "region" {}
+
 provider "aws" {
   access_key = ""
   secret_key = ""
-  region = ""
+  region = "${var.region}"
 }
 
 module "aws-dc" {
   source = "./terraform/aws"
   availability_zone = "us-east-1e"
   ssh_username = "centos"
-  source_ami = "ami-96a818fe"
+  source_ami = "${lookup(var.amis, var.region)}"
 
   control_count = 3
   worker_count = 3

--- a/terraform/aws.sample.tf
+++ b/terraform/aws.sample.tf
@@ -1,4 +1,17 @@
-variable "region" {}
+variable "amis" {
+	default = {
+		us-east-1      = "ami-61bbf104"
+		us-west-2      = "ami-d440a6e7"
+		us-west-1      = "ami-f77fbeb3"
+		eu-central-1   = "ami-e68f82fb"
+		eu-west-1      = "ami-33734044"
+		ap-southeast-1 = "ami-2a7b6b78"
+		ap-southeast-2 = "ami-d38dc6e9"
+		ap-northeast-1 = "ami-b80b6db8"
+		sa-east-1      = "ami-fd0197e0"
+	}
+}
+variable "region" { default = "us-east-1" }
 
 provider "aws" {
   access_key = ""

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -1,16 +1,3 @@
-variable "amis" {
-	default = {
-		us-east-1      = "ami-61bbf104"
-		us-west-2      = "ami-d440a6e7"
-		us-west-1      = "ami-f77fbeb3"
-		eu-central-1   = "ami-e68f82fb"
-		eu-west-1      = "ami-33734044"
-		ap-southeast-1 = "ami-2a7b6b78"
-		ap-southeast-2 = "ami-d38dc6e9"
-		ap-northeast-1 = "ami-b80b6db8"
-		sa-east-1      = "ami-fd0197e0"
-	}
-}
 variable "availability_zone" {}
 variable "control_count" {default = "3"}
 variable "control_iam_profile" {default = "" }
@@ -28,7 +15,7 @@ variable "long_name" {default = "microservices-infastructure"}
 variable "network_ipv4" {default = "10.0.0.0/16"}
 variable "network_subnet_ip4" {default = "10.0.0.0/16"}
 variable "short_name" {default = "mi"}
-variable "source_ami" { }
+variable "source_ami" {}
 variable "ssh_key" {default = "~/.ssh/id_rsa.pub"}
 variable "ssh_username"  {default = "centos"}
 variable "worker_count" {default = "1"}

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -1,14 +1,14 @@
 variable "amis" {
 	default = {
-		us-east-1      = "ami-96a818fe"
-		us-west-2      = "ami-c7d092f7"
-		us-west-1      = "ami-6bcfc42e"
-		eu-central-1   = "ami-7cc4f661"
-		eu-west-1      = "ami-e4ff5c93"
-		ap-southeast-1 = "ami-aea582fc"
-		ap-southeast-2 = "ami-bd523087"
-		ap-northeast-1 = "ami-89634988"
-		sa-east-1      = "ami-bf9520a2"
+		us-east-1      = "ami-61bbf104"
+		us-west-2      = "ami-d440a6e7"
+		us-west-1      = "ami-f77fbeb3"
+		eu-central-1   = "ami-e68f82fb"
+		eu-west-1      = "ami-33734044"
+		ap-southeast-1 = "ami-2a7b6b78"
+		ap-southeast-2 = "ami-d38dc6e9"
+		ap-northeast-1 = "ami-b80b6db8"
+		sa-east-1      = "ami-fd0197e0"
 	}
 }
 variable "availability_zone" {}

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -1,14 +1,14 @@
 variable "amis" {
 	default = {
-		us-east-1      = ami-96a818fe
-		us-west-2      = ami-c7d092f7
-		us-west-1      = ami-6bcfc42e
-		eu-central-1   = ami-7cc4f661
-		eu-west-1      = ami-e4ff5c93
-		ap-southeast-1 = ami-aea582fc
-		ap-southeast-2 = ami-bd523087
-		ap-northeast-1 = ami-89634988
-		sa-east-1      = ami-bf9520a2
+		us-east-1      = "ami-96a818fe"
+		us-west-2      = "ami-c7d092f7"
+		us-west-1      = "ami-6bcfc42e"
+		eu-central-1   = "ami-7cc4f661"
+		eu-west-1      = "ami-e4ff5c93"
+		ap-southeast-1 = "ami-aea582fc"
+		ap-southeast-2 = "ami-bd523087"
+		ap-northeast-1 = "ami-89634988"
+		sa-east-1      = "ami-bf9520a2"
 	}
 }
 variable "availability_zone" {}

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -1,3 +1,16 @@
+variable "amis" {
+	default = {
+		us-east-1      = ami-96a818fe
+		us-west-2      = ami-c7d092f7
+		us-west-1      = ami-6bcfc42e
+		eu-central-1   = ami-7cc4f661
+		eu-west-1      = ami-e4ff5c93
+		ap-southeast-1 = ami-aea582fc
+		ap-southeast-2 = ami-bd523087
+		ap-northeast-1 = ami-89634988
+		sa-east-1      = ami-bf9520a2
+	}
+}
 variable "availability_zone" {}
 variable "control_count" {default = "3"}
 variable "control_iam_profile" {default = "" }


### PR DESCRIPTION
This adds the list of suggested AMI ids to the sample file, and a variable for the region. Users need only edit the region var and the rest of the configuration flows from that. This is for #866. 