### PR TITLE
set selinux to permissive mode when glusterfs is included

### DIFF
--- a/roles/glusterfs/defaults/main.yml
+++ b/roles/glusterfs/defaults/main.yml
@@ -2,7 +2,7 @@
 glusterfs_version: 3.7.6
 glusterfs_minor_version: 3.7
 glusterfs_repo: https://download.gluster.org/pub/gluster/glusterfs/{{ glusterfs_minor_version }}/{{ glusterfs_version }}/EPEL.repo/glusterfs-epel.repo
-glusterfs_repo_sha256sum: 2e2e85fe728b04d19be098b218bd70e304bc33bdf55cbdb8ab86b9d65e7d8538
+glusterfs_repo_sha256sum: ee06398d5b09d230fa3ffad4995b83089012a426265741c58a70bf587d14613c
 
 glusterfs_mode: client
 glusterfs_replication: "{{ groups[glusterfs_server_group] | count }}"

--- a/roles/glusterfs/tasks/main.yml
+++ b/roles/glusterfs/tasks/main.yml
@@ -19,6 +19,14 @@
   tags:
     - glusterfs
 
+- name: set selinux to permissive mode
+  sudo: yes
+  selinux:
+    policy: targeted
+    state: permissive
+  tags:
+    - glusterfs
+
 - include: server.yml
   when: glusterfs_mode == "server" and glusterfs_brick_device != ""
 


### PR DESCRIPTION
- glusterfs will only work when selinux is in permissive mode: http://www.gluster.org/pipermail/gluster-users/2015-November/024476.html
- also updates glusterfs repo checksum

Fixes #867 