### PR TITLE
[WIP] Add basic ELK code.

### DIFF
--- a/roles/elasticsearch/README.rst
+++ b/roles/elasticsearch/README.rst
@@ -1,0 +1,15 @@
+Elasticsearch
+========
+
+Elasticsearch database using the Mesos Elasticsearch framework
+
+Variables
+---------
+
+You can use these variables to customize your Elasticsearch installations:
+
+.. data :: example_option_name
+
+   Example text
+
+   Default: false

--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+elasticsearch_image: pnwtrifork/elasticsearch-scheduler
+elasticsearch_image_tag: 0.23.0
+elasticsearch_executor_image: pnwtrifork/elasticsearch-executor
+elasticsearch_executor_image_tag: 0.23.0
+
+
+
+marathon_port: 18080
+marathon_url: http://marathon.service.{{ consul_dns_domain }}:{{ marathon_port }}
+zookeeper_port: 2181
+zookeeper_dns: zookeeper.service.{{ consul_dns_domain }}
+mesos_zk_chroot: mesos
+
+
+elasticsearchRam: 4096
+elasticsearchClusterName: Mantl
+frameworkName: elasticsearch
+elasticsearch_data_dir: /tmp/mesos/slaves/elasticsearch

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -1,0 +1,31 @@
+# Check we can ping marathon (GET) to a page and it returns a status 200
+- name: ping marathon
+  uri:
+    url: "http://localhost:18080/v2/apps"
+    method: GET
+    status_code: 200
+  run_once: true
+  tags:
+    - elasticsearch
+
+- name: create json files for jobs
+  sudo: yes
+  template:
+    src: '{{ item }}.json.j2'
+    dest: /etc/marathon/{{ item }}.json
+  run_once: true
+  with_items:
+    - elasticsearch
+  tags:
+    - elasticsearch
+
+- name: start jobs
+  run_once: true
+  sudo: yes
+  command: 'curl -X PUT -d@/etc/marathon/{{ item }}.json -H "Content-Type: application/json" http://localhost:18080/v2/apps/{{ item }}'
+  changed_when: false
+  run_once: true
+  with_items:
+    - elasticsearch
+  tags:
+    - elasticsearch

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -1,4 +1,16 @@
 # Check we can ping marathon (GET) to a page and it returns a status 200
+- name: install required python modules
+  sudo: yes
+  pip:
+    name: "{{ item.name }}"
+    state: latest
+  with_items:
+    - name: python-consul
+    - name: httplib2
+  tags:
+    - bootstrap
+    - elasticsearch
+
 - name: ping marathon
   uri:
     url: "http://localhost:18080/v2/apps"

--- a/roles/elasticsearch/templates/elasticsearch.json.j2
+++ b/roles/elasticsearch/templates/elasticsearch.json.j2
@@ -1,0 +1,25 @@
+{
+  "id": "elasticsearch",
+  "container": {
+    "docker": {
+      "image": "{{ elasticsearch_image }}:{{ elasticsearch_image_tag }}",
+      "network": "HOST",
+      "forcePullImage": true
+    }
+  },
+  "args": [
+    "--zookeeperMesosUrl", "zk://{{ zookeeper_dns }}:{{ zookeeper_port }}/{{ mesos_zk_chroot }}",
+    "--executorImage", "{{ elasticsearch_executor_image }}:{{ elasticsearch_executor_image_tag }}",
+    "--executorForcePullImage", "true",
+    "--elasticsearchRam", "{{ elasticsearchRam }}",
+    "--elasticsearchClusterName", "{{ elasticsearchClusterName }}",
+    "--frameworkName", "{{ frameworkName }}",
+    "--dataDir", "{{ elasticsearch_data_dir }}"
+    ],
+  "cpus": 0.2,
+  "mem": 512.0,
+  "env": {
+    "JAVA_OPTS": "-Xms128m -Xmx256m"
+  },
+  "instances": 1
+}

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
-haproxy_image: ciscocloud/haproxy-consul
-haproxy_image_tag: 0.2
+#haproxy_image: ciscocloud/haproxy-consul
+#haproxy_image_tag: 0.2
+
+haproxy_image: corebug/haproxy-consul
+haproxy_image_tag: 0.2-es-alpha
 
 # Set the domain that haproxy uses to match URLs to internal apps.
 # For example, if all your apps will be

--- a/roles/kibana/defaults/main.yml
+++ b/roles/kibana/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+kibana_image: kibana
+kibana_image_tag: 4.1.2
+elasticsearch_framework_executor_name: elasticsearch-executor

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: create json files for jobs
+  sudo: yes
+  template:
+    src: 'kibana.json.j2'
+    dest: /etc/marathon/kibana.json
+  run_once: true
+  tags:
+    - kibana
+
+- name: destroy jobs
+  run_once: true
+  sudo: yes
+  command: 'curl -X DELETE http://localhost:18080/v2/apps/kibana'
+  changed_when: false
+  run_once: true
+  tags:
+    - kibana
+
+- name: start jobs
+  run_once: true
+  sudo: yes
+  run_once: true
+  command: 'curl -X PUT -d@/etc/marathon/kibana.json -H "Content-Type: application/json" http://localhost:18080/v2/apps/kibana'
+  changed_when: false
+  tags:
+    - kibana

--- a/roles/kibana/templates/kibana.json.j2
+++ b/roles/kibana/templates/kibana.json.j2
@@ -1,0 +1,32 @@
+{
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{ kibana_image }}:{{ kibana_image_tag }}",
+      "network": "BRIDGE",
+      "portMappings": [
+          {
+              "containerPort": 5601,
+              "hostPort": 0,
+              "protocol": "tcp"
+          }
+      ]
+    }
+  },
+  "env": {
+    "ELASTICSEARCH_URL": "http://{{ elasticsearch_framework_executor_name }}.service.consul:9200"
+  },
+  "healthChecks": [{
+    "protocol": "HTTP",
+    "path": "/",
+    "portIndex": 0
+  }],
+  "id": "kibana",
+  "instances": 1,
+  "cpus": 0.1,
+  "mem": 128,
+  "ports": [
+    5601
+  ]
+}
+

--- a/roles/logstash/defaults/main.yml
+++ b/roles/logstash/defaults/main.yml
@@ -12,9 +12,10 @@ logstash_log4j_port: 4560
 
 # Logstash output Elasticsearch
 # If defined - logstash will send all the messages to elasticsearch cluster
-# logstash_output_elasticsearch:
-#   host: "elasticsearch.example.com"
-#   protocol: "http"
+logstash_output_elasticsearch:
+  host: "elasticsearch-executor.service.consul"
+  port: 9200
+  protocol: "http"
 
 # Logstash output Kafka
 # If defined - logstash will send all the messages to configured kafka brokers


### PR DESCRIPTION
# Work in progress

TODO:
- [x] Add basic ELK stack code (tested, works)
- [x] Extend [haproxy-consul](https://github.com/CiscoCloud/haproxy-consul) image to include ES proxy configuration (done via https://github.com/CiscoCloud/haproxy-consul/commit/7153c9fba340f52fa0c7d22ae5b13811e8493cbc)
- [ ] stop using `corebug/haproxy-consul:0.2-es-alpha`
- [ ] Make ES node count configurable via a variable
- [ ] Include default dashboard in Kibana with basic charts (CPU, Mem, Mesos etc) 
- [ ] Create architecture diagram image and attach it to ES/Kibana doc pages
- [ ] **Switch to Mantl-API for installing ES and Kibana packages**

I'll update the PR once everything is finished.