### PR TITLE
Updates glusterfs repo checksum

### DIFF
--- a/roles/glusterfs/defaults/main.yml
+++ b/roles/glusterfs/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 glusterfs_version: 3.7.3
 glusterfs_minor_version: 3.7
-glusterfs_repo_sha256sum: 990b1a5f09f5ca555b2d7b94825d896a84d15bd0db2c085cb8f6259215e1d91a
+glusterfs_repo_sha256sum: ee06398d5b09d230fa3ffad4995b83089012a426265741c58a70bf587d14613c
 
 glusterfs_mode: client
 glusterfs_replication: "{{ groups[glusterfs_server_group] | count }}"


### PR DESCRIPTION
This PR updates glusterfs repo checksum. So, solve this error:

```
TASK: [glusterfs | enable community repo] ************************************* 
failed: [mi-control-02] => {"failed": true}
msg: The SHA-256 checksum for /etc/yum.repos.d/glusterfs-epel.repo did not match 2e2e85fe728b04d19be098b218bd70e304bc33bdf55cbdb8ab86b9d65e7d8538; it was ee06398d5b09d230fa3ffad4995b83089012a426265741c58a70bf587d14613c.
failed: [mi-control-01] => {"failed": true}
msg: The SHA-256 checksum for /etc/yum.repos.d/glusterfs-epel.repo did not match 2e2e85fe728b04d19be098b218bd70e304bc33bdf55cbdb8ab86b9d65e7d8538; it was ee06398d5b09d230fa3ffad4995b83089012a426265741c58a70bf587d14613c.

FATAL: all hosts have already failed -- aborting

```