### PR TITLE
Use host FQDN for logstash docker container hostname

### DIFF
--- a/roles/logstash/templates/logstash-service.j2
+++ b/roles/logstash/templates/logstash-service.j2
@@ -15,7 +15,7 @@ ExecStartPre=-/usr/bin/docker pull {{ logstash_image }}:{{ logstash_image_tag }}
 ExecStart=/usr/bin/docker run \
     --rm \
     --name=logstash \
-    --hostname={{ inventory_nodename }} \
+    --hostname={{ ansible_nodename }} \
     --log-driver=none \
     --privileged=true \
     --publish=1514:1514 \

--- a/roles/logstash/templates/logstash-service.j2
+++ b/roles/logstash/templates/logstash-service.j2
@@ -15,7 +15,7 @@ ExecStartPre=-/usr/bin/docker pull {{ logstash_image }}:{{ logstash_image_tag }}
 ExecStart=/usr/bin/docker run \
     --rm \
     --name=logstash \
-    --hostname={{ inventory_hostname }} \
+    --hostname={{ inventory_nodename }} \
     --log-driver=none \
     --privileged=true \
     --publish=1514:1514 \


### PR DESCRIPTION
When sending messages Logstash uses container hostname, not the host hostname.
Using FQDN instead of short name is more preferred way.