### PR TITLE
Use inventory_hostname for setting ACLs

### DIFF
--- a/roles/chronos/defaults/main.yml
+++ b/roles/chronos/defaults/main.yml
@@ -15,7 +15,7 @@ chronos_zk_mesos_master: "zk://{{ chronos_zk_dns }}:{{ chronos_zk_port }}/mesos"
 chronos_zk_acl_world: "world:anyone:cdrwa"
 chronos_zk_acl: "{% if zk_chronos_user_secret is defined %}digest:{{ zk_chronos_user }}:{{ zk_chronos_user_secret_digest}}:cdraw{% endif  %}"
 
-chronos_zk_acl_cmd: "zookeepercli -servers {{ inventory_hostname }}:{{ chronos_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ chronos_zk_chroot }} '{{ chronos_zk_acl_world }},{{ chronos_zk_acl }}'"
+chronos_zk_acl_cmd: "zookeepercli -servers localhost:{{ chronos_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ chronos_zk_chroot }} '{{ chronos_zk_acl_world }},{{ chronos_zk_acl }}'"
 
 chronos_port: 14400
 chronos_proxy_port: 4400

--- a/roles/chronos/defaults/main.yml
+++ b/roles/chronos/defaults/main.yml
@@ -15,7 +15,7 @@ chronos_zk_mesos_master: "zk://{{ chronos_zk_dns }}:{{ chronos_zk_port }}/mesos"
 chronos_zk_acl_world: "world:anyone:cdrwa"
 chronos_zk_acl: "{% if zk_chronos_user_secret is defined %}digest:{{ zk_chronos_user }}:{{ zk_chronos_user_secret_digest}}:cdraw{% endif  %}"
 
-chronos_zk_acl_cmd: "zookeepercli -servers {{ chronos_zk_dns }}:{{ chronos_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ chronos_zk_chroot }} '{{ chronos_zk_acl_world }},{{ chronos_zk_acl }}'"
+chronos_zk_acl_cmd: "zookeepercli -servers {{ inventory_hostname }}:{{ chronos_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ chronos_zk_chroot }} '{{ chronos_zk_acl_world }},{{ chronos_zk_acl }}'"
 
 chronos_port: 14400
 chronos_proxy_port: 4400

--- a/roles/chronos/tasks/main.yml
+++ b/roles/chronos/tasks/main.yml
@@ -26,7 +26,7 @@
     - marathon
 
 - name: wait for zookeeper to listen
-  command: "/usr/local/bin/zookeeper-wait-for-listen.sh {{ inventory_hostname }}"
+  command: "/usr/local/bin/zookeeper-wait-for-listen.sh localhost"
 
 - name: create zookeeper acl
   sudo: yes
@@ -36,6 +36,10 @@
     - restart chronos
   when: zk_chronos_user_secret is defined
   run_once: true
+  register: zk_acl_chronos
+  until: zk_acl_chronos.rc == 0
+  retries: 5
+  delay: 10
   tags:
     - chronos
 

--- a/roles/chronos/tasks/main.yml
+++ b/roles/chronos/tasks/main.yml
@@ -25,8 +25,12 @@
   tags:
     - marathon
 
+- name: wait for zookeeper to listen
+  command: "/usr/local/bin/zookeeper-wait-for-listen.sh {{ inventory_hostname }}"
+
 - name: create zookeeper acl
   sudo: yes
+  run_once: yes
   command: "{{ chronos_zk_acl_cmd }}"
   notify:
     - restart chronos

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -11,7 +11,7 @@ marathon_zk_connect: "zk://{{ marathon_zk_auth}}{{ marathon_zk_dns }}:{{ maratho
 marathon_zk_acl_world: "world:anyone:cdrwa"
 marathon_zk_acl: "{% if zk_marathon_user_secret is defined %}digest:{{ zk_marathon_user }}:{{ zk_marathon_user_secret_digest}}:cdraw{% endif  %}"
 
-marathon_zk_acl_cmd: "zookeepercli -servers {{ marathon_zk_dns }}:{{ marathon_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ marathon_zk_chroot }} '{{ marathon_zk_acl_world }},{{ marathon_zk_acl }}'"
+marathon_zk_acl_cmd: "zookeepercli -servers {{ inventory_hostname }}:{{ marathon_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ marathon_zk_chroot }} '{{ marathon_zk_acl_world }},{{ marathon_zk_acl }}'"
 
 marathon_http_credentials: ""
 marathon_keystore_path: ""

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -11,7 +11,7 @@ marathon_zk_connect: "zk://{{ marathon_zk_auth}}{{ marathon_zk_dns }}:{{ maratho
 marathon_zk_acl_world: "world:anyone:cdrwa"
 marathon_zk_acl: "{% if zk_marathon_user_secret is defined %}digest:{{ zk_marathon_user }}:{{ zk_marathon_user_secret_digest}}:cdraw{% endif  %}"
 
-marathon_zk_acl_cmd: "zookeepercli -servers {{ inventory_hostname }}:{{ marathon_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ marathon_zk_chroot }} '{{ marathon_zk_acl_world }},{{ marathon_zk_acl }}'"
+marathon_zk_acl_cmd: "zookeepercli -servers localhost:{{ marathon_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ marathon_zk_chroot }} '{{ marathon_zk_acl_world }},{{ marathon_zk_acl }}'"
 
 marathon_http_credentials: ""
 marathon_keystore_path: ""

--- a/roles/marathon/tasks/conf.yml
+++ b/roles/marathon/tasks/conf.yml
@@ -10,7 +10,7 @@
     - marathon
 
 - name: wait for zookeeper to listen
-  command: "/usr/local/bin/zookeeper-wait-for-listen.sh {{ inventory_hostname }}"
+  command: "/usr/local/bin/zookeeper-wait-for-listen.sh localhost"
 
 - name: create zookeeper acl
   sudo: yes
@@ -20,6 +20,10 @@
     - restart marathon
   when: zk_marathon_user_secret is defined
   run_once: true
+  register: zk_acl_marathon
+  until: zk_acl_marathon.rc == 0
+  retries: 5
+  delay: 10
   tags:
     - marathon
 

--- a/roles/marathon/tasks/conf.yml
+++ b/roles/marathon/tasks/conf.yml
@@ -9,8 +9,12 @@
   tags:
     - marathon
 
+- name: wait for zookeeper to listen
+  command: "/usr/local/bin/zookeeper-wait-for-listen.sh {{ inventory_hostname }}"
+
 - name: create zookeeper acl
   sudo: yes
+  run_once: yes
   command: "{{ marathon_zk_acl_cmd }}"
   notify:
     - restart marathon

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -23,7 +23,7 @@ mesos_leaders_group: role=control
 mesos_zk_acl_world: "world:anyone:r"
 mesos_zk_acl: "{% if zk_mesos_user_secret is defined %}digest:{{ zk_mesos_user }}:{{ zk_mesos_user_secret_digest}}:cdraw{% endif %}"
 
-mesos_zk_acl_cmd: "zookeepercli -servers {{ mesos_zk_dns }}:{{ mesos_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ mesos_zk_chroot }} '{{ mesos_zk_acl_world }},{{ mesos_zk_acl }}'"
+mesos_zk_acl_cmd: "zookeepercli -servers {{ inventory_hostname }}:{{ mesos_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ mesos_zk_chroot }} '{{ mesos_zk_acl_world }},{{ mesos_zk_acl }}'"
 
 # authentication options
 mesos_credentials: []

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -23,7 +23,7 @@ mesos_leaders_group: role=control
 mesos_zk_acl_world: "world:anyone:r"
 mesos_zk_acl: "{% if zk_mesos_user_secret is defined %}digest:{{ zk_mesos_user }}:{{ zk_mesos_user_secret_digest}}:cdraw{% endif %}"
 
-mesos_zk_acl_cmd: "zookeepercli -servers {{ inventory_hostname }}:{{ mesos_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ mesos_zk_chroot }} '{{ mesos_zk_acl_world }},{{ mesos_zk_acl }}'"
+mesos_zk_acl_cmd: "zookeepercli -servers localhost:{{ mesos_zk_port }} -auth_usr='super' -auth_pwd='{{ zk_super_user_secret }}' -force -c setacl /{{ mesos_zk_chroot }} '{{ mesos_zk_acl_world }},{{ mesos_zk_acl }}'"
 
 # authentication options
 mesos_credentials: []

--- a/roles/mesos/tasks/leader.yml
+++ b/roles/mesos/tasks/leader.yml
@@ -41,7 +41,7 @@
     - marathon
 
 - name: wait for zookeeper to listen
-  command: "/usr/local/bin/zookeeper-wait-for-listen.sh {{ inventory_hostname }}"
+  command: "/usr/local/bin/zookeeper-wait-for-listen.sh localhost"
 
 - name: create zookeeper acl
   sudo: yes
@@ -51,6 +51,10 @@
     - restart mesos leader
   when: zk_mesos_user_secret is defined
   run_once: true
+  register: zk_acl_mesos
+  until: zk_acl_mesos.rc == 0
+  retries: 5
+  delay: 10
   tags:
     - mesos
 

--- a/roles/mesos/tasks/leader.yml
+++ b/roles/mesos/tasks/leader.yml
@@ -40,8 +40,12 @@
   tags:
     - marathon
 
+- name: wait for zookeeper to listen
+  command: "/usr/local/bin/zookeeper-wait-for-listen.sh {{ inventory_hostname }}"
+
 - name: create zookeeper acl
   sudo: yes
+  run_once: yes
   command: "{{ mesos_zk_acl_cmd }}"
   notify:
     - restart mesos leader


### PR DESCRIPTION
Parttialy revert to wait-for-zookeeper script, but still use
wait_for to check consul registration.

Set ACLs only on once node of clusters via local interface