### PR TITLE
Fix #920 logstash conditional

### DIFF
--- a/roles/logstash/templates/logstash.conf.j2
+++ b/roles/logstash/templates/logstash.conf.j2
@@ -1,5 +1,5 @@
 input {
-{% if "'role=control' in group_names" %}
+{% if 'role=control' in group_names %}
   file {
     path => [ "/logs/mesos/*.INFO", "/logs/mesos/*.WARNING", "/logs/mesos/*.ERROR", "/logs/mesos/*.FATAL" ]
     type => "mesos-master-logs"
@@ -14,7 +14,7 @@ input {
     type => zookeeper
   }
 {% endif %}
-{% if "'role=worker' in group_names" %}
+{% if 'role=worker' in group_names %}
   file {
     path => [ "/logs/mesos/*.INFO", "/logs/mesos/*.WARNING", "/logs/mesos/*.ERROR", "/logs/mesos/*.FATAL" ]
     type => "mesos-slave-logs"


### PR DESCRIPTION
Fixes #920  where logstash was being configured to send both master and agent logs on all nodes. 