### PR TITLE
Add edge_data_volume_size to Terraform samples

### DIFF
--- a/terraform/openstack-floating.sample.tf
+++ b/terraform/openstack-floating.sample.tf
@@ -25,4 +25,5 @@ module "dc2-hosts-floating" {
   external_net_id = ""
   control_data_volume_size = 20
   worker_data_volume_size = 100
+  edge_data_volume_size = 20
 }

--- a/terraform/openstack.sample.tf
+++ b/terraform/openstack.sample.tf
@@ -25,4 +25,5 @@ module "dc2-hosts" {
   security_groups = ""
   control_data_volume_size = 20
   worker_data_volume_size = 100
+  edge_data_volume_size = 20
 }


### PR DESCRIPTION
Users should be aware of this variable which is missing in OpenStack
Terraform sample files.