### PR TITLE
Fix sudo in terraform/gce/disk.sh dracut command

### DIFF
--- a/terraform/gce/disk.sh
+++ b/terraform/gce/disk.sh
@@ -1,5 +1,5 @@
 # resizes the gce boot disk to the specified *_volume_size
 sudo yum -y install epel-release
 sudo yum -y install cloud-init cloud-initramfs-tools dracut-modules-growroot cloud-utils-growpart
-sudo rpm -qa kernel | sed -e 's/^kernel-//' | xargs -I {} dracut -f /boot/initramfs-{}.img {}
+rpm -qa kernel | sed -e 's/^kernel-//' | xargs -I {} sudo dracut -f /boot/initramfs-{}.img {}
 sudo reboot


### PR DESCRIPTION
The script currently runs:
`sudo rpm -qa kernel | sed -e 's/^kernel-//' | xargs -I {} dracut -f /boot/initramfs-{}.img {}`
which is effectively:
`"sudo rpm -qa kernel" | sed -e 's/^kernel-//' | xargs -I {} dracut -f /boot/initramfs-{}.img {}`

The `dracut` command requires the elevated rights so change `dracut` to `sudo dracut`