### PR TITLE
Include ssh_user in OpenStack Terraform examples

### DIFF
--- a/terraform/openstack-floating.sample.tf
+++ b/terraform/openstack-floating.sample.tf
@@ -17,6 +17,7 @@ module "dc2-hosts-floating" {
   worker_flavor_name  = ""
   edge_flavor_name  = ""
   image_name = ""
+  ssh_user = "centos"
   keypair_name = "${ module.dc2-keypair.keypair_name }"
   control_count = 3
   worker_count = 3

--- a/terraform/openstack.sample.tf
+++ b/terraform/openstack.sample.tf
@@ -18,6 +18,7 @@ module "dc2-hosts" {
   edge_flavor_name = ""
   net_id = ""
   image_name = ""
+  ssh_user = "centos"
   keypair_name = "${ module.dc2-keypair.keypair_name }"
   control_count = 3
   worker_count = 3


### PR DESCRIPTION
Allows to choose SSH user depending on the image. Related to issue https://github.com/CiscoCloud/microservices-infrastructure/issues/947
Tested on CIS.