### PR TITLE
Add ansible lint tool, fix reported issues

### DIFF
--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -36,7 +36,7 @@
   vars:
     haproxy_domain: mi-lb.example.com
   roles:
-    - {role: k8s-minion, tags: k8s} 
+    - {role: k8s-minion, tags: k8s}
 
 # GlusterFS has to be provisioned in reverse order from Mesos: servers then
 # clients.

--- a/kubernetes_vars.yml
+++ b/kubernetes_vars.yml
@@ -9,7 +9,7 @@ minion_group_name: role=worker
 etcd_url_scheme: http
 
 
-# Kubernetes build to use, stable is used by default. 
+# Kubernetes build to use, stable is used by default.
 # Place "testing" here to use latest build avialable.
 kube_build: stable
 

--- a/playbooks/show-package-drift.yml
+++ b/playbooks/show-package-drift.yml
@@ -27,9 +27,11 @@
       run_once: yes
 
     - name: get list of packages installed on host
-      shell: rpm -qa | sort -V # ansible lint does not like this, wants to use yum module
+      shell: rpm -qa | sort -V
       register: packages
       changed_when: no
+      tags:
+        - skip_ansible_lint
 
     - name: write package manifest for host to tmp directory
       local_action:

--- a/playbooks/show-package-drift.yml
+++ b/playbooks/show-package-drift.yml
@@ -14,7 +14,7 @@
       shell: ls -1 {{ tmp_dir }}
       register: files
       changed_when: no
-      delegate_to: localhost 
+      delegate_to: localhost
       run_once: yes
 
     - name: purge existing files
@@ -23,11 +23,11 @@
         state: absent
       with_items: files.stdout_lines
       when: files.stdout_lines|count > 0
-      delegate_to: localhost 
+      delegate_to: localhost
       run_once: yes
 
     - name: get list of packages installed on host
-      shell: rpm -qa | sort -V
+      shell: rpm -qa | sort -V # ansible lint does not like this, wants to use yum module
       register: packages
       changed_when: no
 

--- a/playbooks/trace-consul-wan-traffic.yml
+++ b/playbooks/trace-consul-wan-traffic.yml
@@ -11,7 +11,7 @@
 - hosts: consul_servers
   tasks:
     - name: get list of installed packages before installing wireshark
-      command: rpm -qa
+      command: rpm -qa # ansible lint wants to use yum module
       register: packages_before
       changed_when: no
 
@@ -22,7 +22,7 @@
         state: present
 
     - name: get list of installed packages after installing wireshark
-      command: rpm -qa
+      command: rpm -qa # ansible lint wants to use yum module
       register: packages_after
       changed_when: no
 

--- a/playbooks/trace-consul-wan-traffic.yml
+++ b/playbooks/trace-consul-wan-traffic.yml
@@ -11,9 +11,11 @@
 - hosts: consul_servers
   tasks:
     - name: get list of installed packages before installing wireshark
-      command: rpm -qa # ansible lint wants to use yum module
+      command: rpm -qa
       register: packages_before
       changed_when: no
+      tags:
+        - skip_ansible_lint
 
     - name: install wireshark
       sudo: yes
@@ -22,9 +24,11 @@
         state: present
 
     - name: get list of installed packages after installing wireshark
-      command: rpm -qa # ansible lint wants to use yum module
+      command: rpm -qa
       register: packages_after
       changed_when: no
+      tags:
+        - skip_ansible_lint
 
     - name: capture sniffer trace (for 2 minutes)
       sudo: yes

--- a/playbooks/upgrade-packages.yml
+++ b/playbooks/upgrade-packages.yml
@@ -6,11 +6,11 @@
 
   - name: clean yum
     sudo: yes
-    command: yum clean all
+    command: yum clean all # ansible lint wants to use yum module
 
   - name: refresh yum cache
     sudo: yes
-    command: yum makecache
+    command: yum makecache # ansible lint ... and here
 
   - name: upgrade kernel package
     sudo: yes

--- a/playbooks/upgrade-packages.yml
+++ b/playbooks/upgrade-packages.yml
@@ -6,11 +6,15 @@
 
   - name: clean yum
     sudo: yes
-    command: yum clean all # ansible lint wants to use yum module
+    command: yum clean all
+    tags:
+      - skip_ansible_lint
 
   - name: refresh yum cache
     sudo: yes
-    command: yum makecache # ansible lint ... and here
+    command: yum makecache
+    tags:
+      - skip_ansible_lint
 
   - name: upgrade kernel package
     sudo: yes

--- a/playbooks/wait-for-hosts.yml
+++ b/playbooks/wait-for-hosts.yml
@@ -7,7 +7,6 @@
                     host="{{ ansible_ssh_host | default(inventory_hostname) }}"
                     search_regex=OpenSSH
                     delay=10
-                    
     - name: ensure that hosts are responding
       command: echo hello
       register: result

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ ansible>=1.9.1,<2.0
 pytest==2.7.1
 PyYAML==3.11
 Sphinx==1.2.3
-ansible-lint
+ansible-lint>=2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ ansible>=1.9.1,<2.0
 pytest==2.7.1
 PyYAML==3.11
 Sphinx==1.2.3
+ansible-lint

--- a/roles/calico/tasks/kubernetes.yml
+++ b/roles/calico/tasks/kubernetes.yml
@@ -3,13 +3,13 @@
   sudo: yes
   file:
     path: /usr/libexec/kubernetes/kubelet-plugins/net/exec/calico/
-    state: directory 
+    state: directory
   tags:
     - calico
 
 - name: Get calico-kubernetes plugin
   sudo: yes
-  get_url: 
+  get_url:
     url: https://github.com/projectcalico/calico-docker/releases/download/v0.5.4/calico_kubernetes
     dest: /usr/libexec/kubernetes/kubelet-plugins/net/exec/calico/calico
     mode: 0755

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -62,7 +62,7 @@
 - name: set calico environment
   sudo: yes
   template:
-    src: calico.env.j2 
+    src: calico.env.j2
     dest: /etc/default/calico
     owner: root
     group: root

--- a/roles/chronos/defaults/main.yml
+++ b/roles/chronos/defaults/main.yml
@@ -3,7 +3,7 @@ chronos_version: 2.3.4
 chronos_package: "chronos-{{ chronos_version }}"
 
 # right now there is an issue with chronos zookeeper connection with auth, so leave it blank for now
-chronos_zk_auth: "" 
+chronos_zk_auth: ""
 chronos_zk_dns: "zookeeper.service.{{ consul_dns_domain }}"
 chronos_zk_port: 2181
 chronos_zk_chroot: chronos

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -77,7 +77,6 @@
     state: present
     regexp: ^.+requiretty$
     line: "# Defaults	requiretty"
-  tags:
 
 - name: configure selinux
   sudo: yes

--- a/roles/consul/tasks/nginx_proxy.yml
+++ b/roles/consul/tasks/nginx_proxy.yml
@@ -1,5 +1,5 @@
 ---
-- name: deploy nginx template 
+- name: deploy nginx template
   sudo: yes
   template:
     src: consul.nginx.j2
@@ -30,7 +30,7 @@
   when: nginx_template.changed
   tags:
     - consul
-    
+
 - name: install nginx admin password
   sudo: yes
   run_once: yes

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -101,7 +101,7 @@
     dest: "{{ item }}"
     line: "PEERDNS=no"
     regexp: ^PEERDNS=.*'
-  with_items: list_of_network_scripts.stdout_lines  
+  with_items: list_of_network_scripts.stdout_lines
   notify:
     - restart networkmanager
   tags:

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -5,7 +5,7 @@ docker_lvm_backed_devicemapper: "{% if provider in ['gce', 'openstack', 'aws'] %
 # Used with docker-storage-setup
 docker_storage_driver: overlay
 
-## Refer to commentaries in ../templates/docker-storage-setup.conf.j2 
+## Refer to commentaries in ../templates/docker-storage-setup.conf.j2
 ## or `man lvcreate` for acceptable sizes, and their syntax
 docker_lvm_data_volume_size: 40%FREE
 docker_lvm_data_volume_size_min: 2G

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -115,6 +115,7 @@
     chdir: /root
   tags:
     - docker
+    - skip_ansible_lint
 
 - name: enable docker
   sudo: yes

--- a/roles/haproxy/handlers/main.yml
+++ b/roles/haproxy/handlers/main.yml
@@ -6,6 +6,6 @@
     - systemctl enable haproxy
     - systemctl daemon-reload
 
-- name: restart haproxy 
+- name: restart haproxy
   sudo: yes
   command: systemctl restart haproxy

--- a/roles/k8s-master/tasks/testing.yml
+++ b/roles/k8s-master/tasks/testing.yml
@@ -1,4 +1,4 @@
-- name: install latest kubernetes master 
+- name: install latest kubernetes master
   sudo: yes
   yum:
     pkg="kubernetes"

--- a/roles/lvm/tasks/volume.yml
+++ b/roles/lvm/tasks/volume.yml
@@ -38,7 +38,7 @@
   sudo: yes
   lvg:
     vg: "{{ lvm_volume_group_name }}"
-    pvs: "{{ lvm_physical_device }}"  
+    pvs: "{{ lvm_physical_device }}"
   when: volume_groups.stdout.find(lvm_volume_group_name) == -1
   tags:
     - docker

--- a/roles/marathon/tasks/jobs.yml
+++ b/roles/marathon/tasks/jobs.yml
@@ -24,7 +24,7 @@
 - name: start jobs
   run_once: true
   sudo: yes
-  command: 'curl -X PUT -d@/etc/marathon/{{ item }}.json -H "Content-Type: application/json" http://localhost:18080/v2/apps/{{ item }}'
+  command: 'curl -X PUT -d@/etc/marathon/{{ item }}.json -H "Content-Type: application/json" http://localhost:18080/v2/apps/{{ item }}' # ansible lint wants to use get_url or uri module
   changed_when: false
   failed_when: "'deploymentId' not in result.stdout"
   register: result

--- a/roles/marathon/tasks/jobs.yml
+++ b/roles/marathon/tasks/jobs.yml
@@ -24,7 +24,7 @@
 - name: start jobs
   run_once: true
   sudo: yes
-  command: 'curl -X PUT -d@/etc/marathon/{{ item }}.json -H "Content-Type: application/json" http://localhost:18080/v2/apps/{{ item }}' # ansible lint wants to use get_url or uri module
+  command: 'curl -X PUT -d@/etc/marathon/{{ item }}.json -H "Content-Type: application/json" http://localhost:18080/v2/apps/{{ item }}'
   changed_when: false
   failed_when: "'deploymentId' not in result.stdout"
   register: result
@@ -33,3 +33,4 @@
     - mantl-api
   tags:
     - marathon
+    - skip_ansible_lint

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -4,7 +4,7 @@ mesos_iteration: 1
 mesos_master_iteration: 1
 mesos_agent_iteration: 1
 
-mesos_mode: follower 
+mesos_mode: follower
 mesos_log_dir: /var/log/mesos
 mesos_work_dir: /var/run/mesos
 mesos_leader_port: 15050

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -5,4 +5,4 @@ vault_command_options: -insecure
 vault_init_json: '{
 	"secret_shares": 5,
 	"secret_threshold": 3
-}'
+}' # ansible lint doesn't like the line split between curly braces

--- a/roles/vault/tasks/bootstrap.yml
+++ b/roles/vault/tasks/bootstrap.yml
@@ -7,6 +7,7 @@
   register: vault_init_output
   tags:
     - vault
+    - skip_ansible_lint
 
 - name: extract keys
   sudo: yes

--- a/roles/zookeeper/handlers/main.yml
+++ b/roles/zookeeper/handlers/main.yml
@@ -2,8 +2,8 @@
 - name: reload systemd daemon
   sudo: yes
   command: systemctl daemon-reload
-  tags: 
-    - zookeeper 
+  tags:
+    - zookeeper
 
 - name: restart zookeeper
   sudo: yes

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -83,7 +83,7 @@
     src: /etc/zookeeper/conf
     dest: /opt/mesosphere/zookeeper/conf
   tags:
-    - zookeeper    
+    - zookeeper
 
 - name: create zookeeper auth digest
   sudo: yes


### PR DESCRIPTION
I installed ansible-lint to my mac and ran the linter for all the playbooks in the project. This PR adds the line for ansible-lint in requirements.txt, and begins to make the project compliant with the linter.

A big chunk of the linter errors were about trailing whitespace: I have taken care of those issues in the first commit. I have also made comments on lines where other warnings occurred, but the use of the `command` module here is because the main modules can't do what we need to do in those playbooks. 

The only other error is for `vault_init_json` string being broken up on multiple lines. This is a 'templating' issue.