### PR TITLE
Fix issue with traling slash in Neutron public URL

### DIFF
--- a/roles/calico/files/neutron_port_update.py
+++ b/roles/calico/files/neutron_port_update.py
@@ -52,7 +52,7 @@ def get_catalog():
                                            }
                   }
               }
-    auth_url = creds['auth_url'] + "/tokens"
+    auth_url = creds['auth_url'].strip('/') + "/tokens"
     r = requests.post(auth_url, headers=headers, data=json.dumps(payload))
 
     parsed_json = json.loads(r.text)
@@ -79,7 +79,7 @@ def list_ports(token, public_url):
     """List Neutron ports"""
 
     headers = {'X-Auth-Token': token}
-    auth_url = public_url + "v2.0/ports"
+    auth_url = public_url.strip('/') + "/v2.0/ports"
     r = requests.get(auth_url, headers=headers)
 
     if r.text:
@@ -103,7 +103,7 @@ def update_port(token, public_url, port_id, mac_address, calico_network):
                           ]
                         }
               }
-    auth_url = public_url + "v2.0/ports/" + port_id
+    auth_url = public_url.strip('/') + "/v2.0/ports/" + port_id
     r = requests.put(auth_url, headers=headers, data=json.dumps(payload))
 
     parsed_json = json.loads(r.text)


### PR DESCRIPTION
Fix issue #968. Neutron public URL in Keystone catalog can contain
trailing slash which may result in incorrect URLs parsing.