### PR TITLE
update upgrade playbooks + docs

### DIFF
--- a/docs/upgrading/index.rst
+++ b/docs/upgrading/index.rst
@@ -4,14 +4,48 @@ Upgrading
 Overview
 --------
 
-Starting with Mantl 0.6, our goal is to support a straightforward upgrade path
+Beginning with Mantl 0.6,  our goal is to support a straightforward upgrade path
 from a cluster running a previous release.
+
+However, upgrade support should be considered alpha at this time; it has not
+been extensively tested on production clusters. Please use with caution and
+report any issues you have with the process.
 
 Upgrading from 0.5.1 to 0.6
 ---------------------------
 
-If you have a running 0.5.1 cluster, you need to perform the following two
-steps:
+If you have a running 0.5.1 cluster, you need to perform the following steps:
+
+Update security.yml
+~~~~~~~~~~~~~~~~~~~
+
+Mantl 0.6 requires some additional settings in the ``security.yml`` file that
+you generated when you built your cluster. To auto-generate the necessary
+settings, you simply need to re-run ``security-setup``:
+
+.. code-block:: shell
+
+  ./security-setup
+
+Of course, if you customized your security settings (manually or using the CLI
+arguments), you should be careful to re-run ``security-setup`` the same way.
+
+For your reference, the following settings have been added:
+
+* consul_acl_marathon_token
+* consul_acl_secure_token
+* consul_dns_domain
+
+A note on consul_dns_domain
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prior to 0.6, the ansible ``consul_dns_domain`` variable was defined in a number
+of different playbooks. It is now included in ``security.yml`` and can be
+customized from a single location. This simplifies the configuration and reduces
+the likelihood of mistakes. If you are working with a customized
+``terraform.yml`` file, you should remove all ``consul_dns_domain`` definitions
+from it and ensure ``consul_dns_domain`` is set as desired in your
+``security.yml``.
 
 Upgrade Consul, Mesos, and Marathon
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/upgrading/index.rst
+++ b/docs/upgrading/index.rst
@@ -47,19 +47,15 @@ the likelihood of mistakes. If you are working with a customized
 from it and ensure ``consul_dns_domain`` is set as desired in your
 ``security.yml``.
 
-Upgrade Consul, Mesos, and Marathon
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Upgrade Distributive, Consul, Mesos, and Marathon
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: shell
 
   ansible-playbook -e @security.yml playbooks/upgrade-0.5.1.yml
 
-This playbook simply includes a couple of other playbooks that perform a rolling
-upgrade of Consul, Mesos, and Marathon. If you want, you can run the following
-playbooks independently:
-
-* playbooks/upgrade-consul.yml
-* playbooks/upgrade-mesos-marathon.yml
+This playbook performans a Distributive upgrade and includes a couple of other
+playbooks that perform a rolling upgrade of Consul, Mesos, and Marathon.
 
 Upgrade to Mantl 0.6
 ~~~~~~~~~~~~~~~~~~~~

--- a/playbooks/upgrade-0.5.1.yml
+++ b/playbooks/upgrade-0.5.1.yml
@@ -1,3 +1,23 @@
 ---
+- hosts: all
+  serial: "{{ serial | default(1) }}"
+  tasks:
+    - include_vars: ../roles/common/defaults/main.yml
+    - name: remove obsolete distributive checks
+      sudo: yes
+      file:
+        name: "/etc/consul/{{ item }}"
+        state: absent
+      with_items:
+        - distributive-marathon-check.json
+        - distributive-nginx-check.json
+        - distributive-vault-check.json
+
+    - name: install distributive
+      sudo: yes
+      yum:
+        name: "{{ distributive_rpm_url }}"
+        state: present
+
 - include: ./upgrade-consul.yml
 - include: ./upgrade-mesos-marathon.yml

--- a/playbooks/upgrade-consul.yml
+++ b/playbooks/upgrade-consul.yml
@@ -21,3 +21,10 @@
  
     - name: wait for leader
       command: /usr/local/bin/consul-wait-for-leader.sh
+
+    - name: create secure acl
+      sudo: yes
+      run_once: yes
+      command: consul-cli acl-update --token={{ consul_acl_master_token }} --name="Mantl Secure Token" --rule='key:secure:write' --rule='service::write' {{ consul_acl_secure_token }}
+      tags:
+        - consul

--- a/playbooks/upgrade-mesos-marathon.yml
+++ b/playbooks/upgrade-mesos-marathon.yml
@@ -74,3 +74,13 @@
 
     - name: set consul maintenance disable
       command: consul maint -disable
+
+- hosts: role=control
+  serial: "{{ serial | default(1) }}"
+  tasks:
+    # collectd gets confused after the mesos upgrade
+    - name: restart collectd
+      sudo: yes
+      service:
+        name: collectd
+        state: restarted

--- a/roles/consul/tasks/nginx_proxy.yml
+++ b/roles/consul/tasks/nginx_proxy.yml
@@ -4,8 +4,6 @@
   template:
     src: consul.nginx.j2
     dest: /etc/consul/consul.nginx
-  register:
-    nginx_template
   tags:
     - consul
 
@@ -26,8 +24,8 @@
 
 - name: install nginx template
   sudo: yes
+  run_once: yes
   command: consul-cli kv-write --token={{ consul_acl_secure_token }} secure/service/nginx/templates/consul @/etc/consul/consul.nginx
-  when: nginx_template.changed
   tags:
     - consul
 


### PR DESCRIPTION
This updates the upgrade playbooks to be compatible with some of the recent PRs (consul, distributive, vault). I've tested on GCE and it works as an upgrade from 0.5.1 to the current master. I suggest we wait until we cut the first RC before more testing.

fixes #1048 