### PR TITLE
Remove kernel version requirement on digitalocean

### DIFF
--- a/addons/glusterfs.yml
+++ b/addons/glusterfs.yml
@@ -5,7 +5,7 @@
 # CHECK SECURITY - when customizing you should leave this in. If you take it out
 # and forget to specify security.yml, security could be turned off on components
 # in your cluster!
-- include: playbooks/check-requirements.yml
+- include: "{{ playbook_dir }}/check-requirements.yml"
 
 - hosts: role=control
   vars:

--- a/addons/glusterfs.yml
+++ b/addons/glusterfs.yml
@@ -5,7 +5,7 @@
 # CHECK SECURITY - when customizing you should leave this in. If you take it out
 # and forget to specify security.yml, security could be turned off on components
 # in your cluster!
-- include: "{{ playbook_dir }}/check-requirements.yml"
+- include: "{{ playbook_dir }}/../playbooks/check-requirements.yml"
 
 - hosts: role=control
   vars:

--- a/playbooks/check-requirements.yml
+++ b/playbooks/check-requirements.yml
@@ -12,7 +12,9 @@
 
     # Change concurrently with the required ansible version in requirements.txt
     - name: check for compatible Ansible version
-      when: ansible_version["string"] | version_compare("1.9.1", "<") or ansible_version["string"] | version_compare("2", ">=")
+      when: >
+        ansible_version["string"] | version_compare("1.9.1", "<")
+        or ansible_version["string"] | version_compare("2", ">=")
       fail:
         msg: |
           Your version of Ansible doesn't match the required version. Please
@@ -30,7 +32,10 @@
           continuing.
 
     - name: check for compatible kernel version
-      when: ansible_kernel | version_compare("3.10.0-327", "<")
+      when: >
+        ansible_kernel | version_compare("3.10.0-327", "<")
+        and provider != "digitalocean"
+        and provider != "packer"
       fail:
         msg: |
           Your hosts don't appear to be running a compatible version of the

--- a/playbooks/consul-join-wan.yml
+++ b/playbooks/consul-join-wan.yml
@@ -1,5 +1,5 @@
 ---
-- include: playbooks/check-requirements.yml
+- include: "{{ playbook_dir }}/check-requirements.yml"
 
 - hosts: consul_servers
   tasks:

--- a/playbooks/reboot-hosts.yml
+++ b/playbooks/reboot-hosts.yml
@@ -1,5 +1,5 @@
 ---
-- include: playbooks/check-requirements.yml
+- include: "{{ playbook_dir }}/check-requirements.yml"
 
 - hosts: all
   serial: 1

--- a/playbooks/upgrade-mesos-marathon.yml
+++ b/playbooks/upgrade-mesos-marathon.yml
@@ -1,5 +1,5 @@
 ---
-- include: playbooks/check-requirements.yml
+- include: "{{ playbook_dir }}/check-requirements.yml"
 
 - hosts: role=worker
   serial: "{{ serial | default(1) }}"

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -2,7 +2,7 @@
 # CHECK SECURITY - when customizing you should leave this in. If you
 # take it out and forget to specify security.yml, security could be turned off
 # on components in your cluster!
-- include: playbooks/check-requirements.yml
+- include: "{{ playbook_dir }}/playbooks/check-requirements.yml"
 
 # BASICS - we need every node in the cluster to have common software running to
 # increase stability and enable service discovery. You can look at the


### PR DESCRIPTION
Tested on DO, deploys sucessfully

Unrelatedly, this also wraps the line of the ansible version requirement. 