### PR TITLE
Fix Distributive link in README

### DIFF
--- a/roles/distributive/README.rst
+++ b/roles/distributive/README.rst
@@ -3,7 +3,7 @@ Distributive
 
 .. versionadded:: 1.1
 
-`Distributive <https://github.com/CiscoCloud/distributive>`_ is used in Mantl to
+`Distributive <https://github.com/mantl/distributive>`_ is used in Mantl to
 run detailed, granular health checks for various services.
 
 This role is run several times as a dependency for other roles.

--- a/roles/distributive/README.rst
+++ b/roles/distributive/README.rst
@@ -3,8 +3,8 @@ Distributive
 
 .. versionadded:: 1.1
 
-`Distributive <https://www.consul.io/>`_ is used in Mantl to run detailed,
-granular health checks for various services.
+`Distributive <https://github.com/CiscoCloud/distributive>`_ is used in Mantl to
+run detailed, granular health checks for various services.
 
 This role is run several times as a dependency for other roles.
 


### PR DESCRIPTION
Distributive link originally pointed to consul.io, instead point to the Github repository for Distributive.

Hi, thank you for your contribution to Mantl! Before we can accept any code into
master, we need it to meet the following criteria. If there are any you can't
satisfy yourself, go ahead and open the pull request anyway and we'll help you
test. Feel free to delete this message once you're done. Thanks again!

- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes
